### PR TITLE
:wrench: restringindo tabela endereco deletar diocese

### DIFF
--- a/prisma/migrations/20250415155610_restrict_endereco/migration.sql
+++ b/prisma/migrations/20250415155610_restrict_endereco/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "diocese" DROP CONSTRAINT "diocese_enderecoId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "paroquia" DROP CONSTRAINT "paroquia_enderecoId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "diocese" ADD CONSTRAINT "diocese_enderecoId_fkey" FOREIGN KEY ("enderecoId") REFERENCES "endereco"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "paroquia" ADD CONSTRAINT "paroquia_enderecoId_fkey" FOREIGN KEY ("enderecoId") REFERENCES "endereco"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -175,7 +175,7 @@ model diocese {
   tipoDiocese   tipoDiocese  @relation(fields: [tipoDioceseId], references: [id])
   descricao     String       @db.VarChar(90)
   enderecoId    Int
-  endereco      endereco     @relation(fields: [enderecoId], references: [id], onDelete: Cascade)
+  endereco      endereco     @relation(fields: [enderecoId], references: [id], onDelete: Restrict)
   paroquias     paroquia[]
   localidade    localidade[]
 }
@@ -184,7 +184,7 @@ model paroquia {
   id         Int               @id @default(autoincrement())
   enderecoId Int
   dioceseId  Int
-  endereco   endereco          @relation(fields: [enderecoId], references: [id], onDelete: Cascade)
+  endereco   endereco          @relation(fields: [enderecoId], references: [id], onDelete: Restrict)
   diocese    diocese           @relation(fields: [dioceseId], references: [id], onDelete: Restrict)
   descricao  String            @db.VarChar(50)
   pessoas    paroquiaPessoas[]


### PR DESCRIPTION
## Resumo por Sourcery

Melhorias:
- Atualização do esquema do banco de dados para restringir a exclusão de registros de endereço que são referenciados pelas tabelas diocese e paroquia

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update database schema to restrict deletion of address records that are referenced by diocese and paroquia tables

</details>