### PR TITLE
:sparkles: cadastro cidade #39

### DIFF
--- a/src/diocese/diocese.service.ts
+++ b/src/diocese/diocese.service.ts
@@ -164,7 +164,6 @@ export class DioceseService {
 
     if (!endereco) {
       this.logger.error(`Endereço id ${id} não encontrada.`);
-      // TODO: add log no sentry
       return;
     }
 
@@ -181,6 +180,14 @@ export class DioceseService {
       });
       this.logger.log(
         `Cadastrado estado ${uf.nome} do endereco id ${id} ${endereco.observacao}`,
+      );
+
+      const cidade = await this.cidadeService.create({
+        nome: endereco.cidade,
+        estado: { sigla: uf.sigla },
+      });
+      this.logger.log(
+        `Cadastrado cidade ${cidade.nome} - ${uf.sigla}. Endereco id: ${id}`,
       );
     } catch (error) {
       this.logger.error(error);


### PR DESCRIPTION
#39

## Resumo por Sourcery

Modifica a lógica de criação de cidades para lidar com cidades existentes e melhora o tratamento de erros no serviço de diocese

Novas Funcionalidades:
- Adiciona a criação automática de cidades ao processar endereços de diocese

Correções de Bugs:
- Impede a criação de cidades duplicadas, retornando a cidade existente em vez de lançar uma exceção

Melhorias:
- Atualiza o serviço de criação de cidades para retornar a cidade existente em vez de lançar um erro
- Melhora o registro (logging) para os processos de criação de cidades e estados

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify city creation logic to handle existing cities and improve error handling in diocese service

New Features:
- Add automatic city creation when processing diocese addresses

Bug Fixes:
- Prevent duplicate city creation by returning existing city instead of throwing an exception

Enhancements:
- Update city creation service to return existing city instead of throwing an error
- Improve logging for city and state creation processes

</details>