### PR TITLE
:sparkles: add get cidade

### DIFF
--- a/src/configuracoes/cidade/cidade.service.ts
+++ b/src/configuracoes/cidade/cidade.service.ts
@@ -7,7 +7,7 @@ import { EstadoService } from '../estado/estado.service';
 export class CidadeService {
   private readonly logger = new Logger(CidadeService.name);
 
-  SELECT_CIDADE = {
+  static readonly SELECT_CIDADE = {
     id: true,
     nome: true,
     estado: {
@@ -57,14 +57,14 @@ export class CidadeService {
 
   findAll() {
     return this.prisma.cidade.findMany({
-      select: this.SELECT_CIDADE,
+      select: CidadeService.SELECT_CIDADE,
     });
   }
 
   findOne(id: number) {
-    return this.prisma.cidade.findFirstOrThrow({
+    return this.prisma.cidade.findUniqueOrThrow({
       where: { id },
-      select: this.SELECT_CIDADE,
+      select: CidadeService.SELECT_CIDADE,
     });
   }
 

--- a/src/configuracoes/cidade/cidade.service.ts
+++ b/src/configuracoes/cidade/cidade.service.ts
@@ -7,6 +7,23 @@ import { EstadoService } from '../estado/estado.service';
 export class CidadeService {
   private readonly logger = new Logger(CidadeService.name);
 
+  SELECT_CIDADE = {
+    id: true,
+    nome: true,
+    estado: {
+      select: {
+        sigla: true,
+        nome: true,
+        pais: {
+          select: {
+            nome: true,
+            lingua: true,
+          },
+        },
+      },
+    },
+  };
+
   constructor(
     private prisma: PrismaService,
     private estadoService: EstadoService,
@@ -39,11 +56,16 @@ export class CidadeService {
   }
 
   findAll() {
-    return `This action returns all cidade`;
+    return this.prisma.cidade.findMany({
+      select: this.SELECT_CIDADE,
+    });
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} cidade`;
+    return this.prisma.cidade.findFirstOrThrow({
+      where: { id },
+      select: this.SELECT_CIDADE,
+    });
   }
 
   private async findByName(nome: string) {

--- a/test/configuracoes/cidade.e2e-spec.ts
+++ b/test/configuracoes/cidade.e2e-spec.ts
@@ -1,0 +1,105 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { setupTestModule } from '../test-setup';
+
+describe('CidadeController (e2e)', () => {
+  let app: INestApplication;
+  const principal = 'cidade';
+
+  beforeAll(async () => {
+    app = await setupTestModule();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it(`/${principal} (GET) - 200 | deve retornar as cidades cadastradas na base`, () => {
+    return request(app.getHttpServer())
+      .get(`/${principal}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toBeInstanceOf(Object);
+        expect(res.body.data).toBeInstanceOf(Array);
+        expect(res.body.data.length).toBeGreaterThan(0);
+
+        const cidade = res.body.data[0];
+        expect(typeof cidade.id).toBe('number');
+        expect(typeof cidade.nome).toBe('string');
+
+        const estado = cidade.estado;
+        expect(estado).toBeInstanceOf(Object);
+        expect(typeof estado.sigla).toBe('string');
+        expect(typeof estado.nome).toBe('string');
+
+        const pais = estado.pais;
+        expect(pais).toBeInstanceOf(Object);
+        expect(typeof pais.nome).toBe('string');
+        expect(typeof pais.lingua).toBe('string');
+      });
+  });
+
+  it(`/${principal}/1 (GET) - 200 | deve retornar uma cidade por id`, () => {
+    return request(app.getHttpServer())
+      .get(`/${principal}/1`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.data.id).toBe(1);
+        expect(res.body.data.nome).toBe('Ibiraci');
+
+        const estado = res.body.data.estado;
+        expect(estado.sigla).toBe('MG');
+        expect(estado.nome).toBe('Minas Gerais');
+
+        const pais = estado.pais;
+        expect(pais.nome).toBe('Brasil');
+        expect(pais.lingua).toBe('portugues');
+      });
+  });
+
+  it(`/${principal}/9999 (GET) - 404 | deve retornar 404 para cidade inexistente`, () => {
+    return request(app.getHttpServer())
+      .get(`/${principal}/9999`)
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(
+          `O registro de 'Cidade' não foi encontrado.`,
+        );
+        expect(res.body.statusCode).toBe(404);
+      });
+  });
+
+  it(`/${principal} (POST) - 404 | cadastro de cidade não é permitido`, () => {
+    return request(app.getHttpServer())
+      .post(`/${principal}`)
+      .send({ nome: 'Cidade Nova' })
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(`Cannot POST /${principal}`);
+        expect(res.body.error).toBe('Not Found');
+        expect(res.body.statusCode).toBe(404);
+      });
+  });
+
+  it(`/${principal}/1 (PUT) - 404 | atualização de cidade não é permitida`, () => {
+    return request(app.getHttpServer())
+      .put(`/${principal}/1`)
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(`Cannot PUT /${principal}/1`);
+        expect(res.body.error).toBe('Not Found');
+        expect(res.body.statusCode).toBe(404);
+      });
+  });
+
+  it(`/${principal}/1 (DELETE) - 404 | exclusão de cidade não é permitida`, () => {
+    return request(app.getHttpServer())
+      .delete(`/${principal}/1`)
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(`Cannot DELETE /${principal}/1`);
+        expect(res.body.error).toBe('Not Found');
+        expect(res.body.statusCode).toBe(404);
+      });
+  });
+});

--- a/test/configuracoes/cidade.e2e-spec.ts
+++ b/test/configuracoes/cidade.e2e-spec.ts
@@ -27,12 +27,12 @@ describe('CidadeController (e2e)', () => {
         expect(typeof cidade.id).toBe('number');
         expect(typeof cidade.nome).toBe('string');
 
-        const estado = cidade.estado;
+        const { estado } = cidade;
         expect(estado).toBeInstanceOf(Object);
         expect(typeof estado.sigla).toBe('string');
         expect(typeof estado.nome).toBe('string');
 
-        const pais = estado.pais;
+        const { pais } = estado;
         expect(pais).toBeInstanceOf(Object);
         expect(typeof pais.nome).toBe('string');
         expect(typeof pais.lingua).toBe('string');


### PR DESCRIPTION
## Resumo por Sourcery

Implementa métodos de consulta ao banco de dados para recuperar informações de cidade usando Prisma ORM

Novos Recursos:
- Adiciona métodos de consulta ao banco de dados para buscar todas as cidades e recuperar uma cidade específica por ID

Melhorias:
- Cria uma configuração `select` reutilizável para consultas de `cidade` que inclui informações relacionadas de `estado` e `pais`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement database query methods for retrieving cidade (city) information using Prisma ORM

New Features:
- Add database query methods to fetch all cities and retrieve a specific city by ID

Enhancements:
- Create a reusable select configuration for cidade queries that includes related estado (state) and pais (country) information

</details>