### PR TITLE
feat: add paroquia

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -7,8 +7,5 @@
 NODE_ENV=development
 DATABASE_URL="postgresql://ambrosio:ambrosio@localhost:5432/ambrosio?schema=ambrosio"
 
-# RabbitMQ connection
-RABBITMQ_URL="amqp://guest:guest@localhost:5672/"
-
 ESTADO_CIVIL_CASADO_ID=2
 JWT_SECRET=seu-jwt-secret

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,21 +20,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
-      rabbitmq:
-        image: rabbitmq:4.1.0-management
-        env:
-          RABBITMQ_DEFAULT_USER: guest
-          RABBITMQ_DEFAULT_PASS: guest
-        ports:
-          - 5672:5672 # Porta do AMQP
-          - 15672:15672 # Painel de administração
-        options: >-
-          --health-cmd "rabbitmqctl status"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: 📥 Checkout código
         uses: actions/checkout@v3
@@ -63,5 +48,4 @@ jobs:
         run: npm run test && npm run test:e2e
         env:
           DATABASE_URL: postgresql://user:password@localhost:5432/mydb
-          RABBITMQ_URL: amqp://guest:guest@localhost:5672
           JWT_SECRET: seu-jwt-secret

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,24 +199,24 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.1.tgz",
+      "integrity": "sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -224,22 +224,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
+      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/helper-compilation-targets": "^7.26.5",
-        "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helpers": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -265,14 +265,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -282,14 +282,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.1.tgz",
+      "integrity": "sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.8",
-        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/compat-data": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -309,29 +309,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
+      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -361,9 +361,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -381,27 +381,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.1.tgz",
+      "integrity": "sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.27.1"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -466,13 +466,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -508,13 +508,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -634,13 +634,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -650,32 +650,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.1.tgz",
+      "integrity": "sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
+      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -694,14 +694,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.1.5.tgz",
-      "integrity": "sha512-qVkyUSCvEmfTVWK92hsCeOQaOODlyBGkZC4ldqb4Fi0Gg8/kOWlcPJVN6i4a9edYYSdICUkGnt6UVFgi59fSrQ==",
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.1.6.tgz",
+      "integrity": "sha512-W5OyhLqUHg8CDy4GC5LBYOyGIq3dxhKNliBZ7xf2Q95+oDzptb3LGp8vwwf1ItEjyGdxM+USDStQPg2oAcxEgw==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.15.1",
@@ -3624,9 +3624,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.6.0.tgz",
-      "integrity": "sha512-vfp73YT/BHsWWOAuthKQ/1lBgESSqYqAWZEYyTdGXyFAHpmewwWL2Iz6ErIzkj4aHbuc6/cGSsE6ZY+pBO04Cg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.7.0.tgz",
+      "integrity": "sha512-+k61zZn1XHjbZul8q6TdQLpuI/cvyfil87zqK2zpreNIXyXtpUv3+H/oM69hcsFcZXaokHJIzPAt5Z8C8eK2QA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3646,9 +3646,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.6.0.tgz",
-      "integrity": "sha512-d8FlXRHsx72RbN8nA2QCRORNv5AcUnPXgtPvwhXmYkQSMF/j9cKaJg+9VcUzBRXGy9QBckNzEQDEJZdEOZ+ubA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.7.0.tgz",
+      "integrity": "sha512-di8QDdvSz7DLUi3OOcCHSwxRNeW7jtGRUD2+Z3SdNE3A+pPiNT8WgUJoUyOwJmUr5t+JA2W15P78C/N+8RXrOA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3657,53 +3657,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.6.0.tgz",
-      "integrity": "sha512-DL6n4IKlW5k2LEXzpN60SQ1kP/F6fqaCgU/McgaYsxSf43GZ8lwtmXLke9efS+L1uGmrhtBUP4npV/QKF8s2ZQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.7.0.tgz",
+      "integrity": "sha512-RabHn9emKoYFsv99RLxvfG2GHzWk2ZI1BuVzqYtmMSIcuGboHY5uFt3Q3boOREM9de6z5s3bQoyKeWnq8Fz22w==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.6.0.tgz",
-      "integrity": "sha512-nC0IV4NHh7500cozD1fBoTwTD1ydJERndreIjpZr/S3mno3P6tm8qnXmIND5SwUkibNeSJMpgl4gAnlqJ/gVlg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.7.0.tgz",
+      "integrity": "sha512-3wDMesnOxPrOsq++e5oKV9LmIiEazFTRFZrlULDQ8fxdub5w4NgRBoxtWbvXmj2nJVCnzuz6eFix3OhIqsZ1jw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.6.0",
-        "@prisma/engines-version": "6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a",
-        "@prisma/fetch-engine": "6.6.0",
-        "@prisma/get-platform": "6.6.0"
+        "@prisma/debug": "6.7.0",
+        "@prisma/engines-version": "6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed",
+        "@prisma/fetch-engine": "6.7.0",
+        "@prisma/get-platform": "6.7.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a.tgz",
-      "integrity": "sha512-JzRaQ5Em1fuEcbR3nUsMNYaIYrOT1iMheenjCvzZblJcjv/3JIuxXN7RCNT5i6lRkLodW5ojCGhR7n5yvnNKrw==",
+      "version": "6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed.tgz",
+      "integrity": "sha512-EvpOFEWf1KkJpDsBCrih0kg3HdHuaCnXmMn7XFPObpFTzagK1N0Q0FMnYPsEhvARfANP5Ok11QyoTIRA2hgJTA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.6.0.tgz",
-      "integrity": "sha512-Ohfo8gKp05LFLZaBlPUApM0M7k43a0jmo86YY35u1/4t+vuQH9mRGU7jGwVzGFY3v+9edeb/cowb1oG4buM1yw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.7.0.tgz",
+      "integrity": "sha512-zLlAGnrkmioPKJR4Yf7NfW3hftcvqeNNEHleMZK9yX7RZSkhmxacAYyfGsCcqRt47jiZ7RKdgE0Wh2fWnm7WsQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.6.0",
-        "@prisma/engines-version": "6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a",
-        "@prisma/get-platform": "6.6.0"
+        "@prisma/debug": "6.7.0",
+        "@prisma/engines-version": "6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed",
+        "@prisma/get-platform": "6.7.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.6.0.tgz",
-      "integrity": "sha512-3qCwmnT4Jh5WCGUrkWcc6VZaw0JY7eWN175/pcb5Z6FiLZZ3ygY93UX0WuV41bG51a6JN/oBH0uywJ90Y+V5eA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.7.0.tgz",
+      "integrity": "sha512-i9IH5lO4fQwnMLvQLYNdgVh9TK3PuWBfQd7QLk/YurnAIg+VeADcZDbmhAi4XBBDD+hDif9hrKyASu0hbjwabw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.6.0"
+        "@prisma/debug": "6.7.0"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -3726,18 +3726,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/@sentry/core": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.14.0.tgz",
-      "integrity": "sha512-OLfucnP3LAL5bxVNWc2RVOHCX7fk9Er5bWPCS+O5cPjqNUUz0HQHhVh2Vhei5C0kYZZM4vy4BQit5T9LrlOaNA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.15.0.tgz",
+      "integrity": "sha512-lBmo3bzzaYUesdzc2H5K3fajfXyUNuj5koqyFoCAI8rnt9CBl7SUc/P07+E5eipF8mxgiU3QtkI7ALzRQN8pqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/nestjs": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nestjs/-/nestjs-9.14.0.tgz",
-      "integrity": "sha512-06gAYewqrwYVaeUocTIF0a41TwnTs+8rPg32/5YibaKm1hdQLzmYHy+jpThr3agHFoyEDsqUIXvlPRN7GzzNXQ==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nestjs/-/nestjs-9.15.0.tgz",
+      "integrity": "sha512-qZ59fYq6PNeG5aSFVLGWsLsRYrKo2Xd3VS2x0/ci6gCP8Ec+STOmm+GyIQOwVbZJxDLqVWlNXV6/8wKVfirHhg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -3745,8 +3745,8 @@
         "@opentelemetry/instrumentation": "0.57.2",
         "@opentelemetry/instrumentation-nestjs-core": "0.44.1",
         "@opentelemetry/semantic-conventions": "^1.30.0",
-        "@sentry/core": "9.14.0",
-        "@sentry/node": "9.14.0"
+        "@sentry/core": "9.15.0",
+        "@sentry/node": "9.15.0"
       },
       "engines": {
         "node": ">=18"
@@ -3757,9 +3757,9 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.14.0.tgz",
-      "integrity": "sha512-AWPc6O+zAdSgnsiKm6Nb1txyiKCOIBriJEONdXFSslgZgkm8EWAYRRHyS2Hkmnz0/5bEQ3jEffIw22qJuaHN+Q==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.15.0.tgz",
+      "integrity": "sha512-K0LdJxIzYbbsbiT+1tKgNq6MUHuDs2DggBDcFEp3T+yXVJYN1AyalUli06Kmxq8yvou6hgLwWL4gjIcB1IQySA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -3793,8 +3793,8 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.30.0",
         "@prisma/instrumentation": "6.6.0",
-        "@sentry/core": "9.14.0",
-        "@sentry/opentelemetry": "9.14.0",
+        "@sentry/core": "9.15.0",
+        "@sentry/opentelemetry": "9.15.0",
         "import-in-the-middle": "^1.13.0"
       },
       "engines": {
@@ -3802,12 +3802,12 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.14.0.tgz",
-      "integrity": "sha512-NnHJjSQGpWaZ6+0QK9Xn1T3CTOM16Ij07VnSiGmVz3/IMsNC1/jndqc8p9BxEI+67XhZjOUUN0Ogpq1XRY7YeA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.15.0.tgz",
+      "integrity": "sha512-gGOzgSxbuh4B4SlEonL1LFsazmeqL/fn5CIQqRG0UWWxdt6TKAMlj0ThIlGF3jSHW2eXdpvs+4E73uFEaHIqfg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.14.0"
+        "@sentry/core": "9.15.0"
       },
       "engines": {
         "node": ">=18"
@@ -5380,9 +5380,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001715",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
-      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
+      "version": "1.0.30001716",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz",
+      "integrity": "sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==",
       "dev": true,
       "funding": [
         {
@@ -5935,9 +5935,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6133,9 +6133,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.143",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.143.tgz",
-      "integrity": "sha512-QqklJMOFBMqe46k8iIOwA9l2hz57V2OKMmP5eSWcUvwx+mASAsbU+wkF1pHjn9ZVSBPrsYWr4/W/95y5SwYg2g==",
+      "version": "1.5.148",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.148.tgz",
+      "integrity": "sha512-8uc1QXwwqayD4mblcsQYZqoi+cOc97A2XmKSBOIRbEAvbp6vrqmSYs4dHD2qVygUgn7Mi0qdKgPaJ9WC8cv63A==",
       "dev": true,
       "license": "ISC"
     },
@@ -9312,9 +9312,9 @@
       }
     },
     "node_modules/module-details-from-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -9418,9 +9418,9 @@
       "license": "MIT"
     },
     "node_modules/neocatecumenal": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/neocatecumenal/-/neocatecumenal-2.1.7.tgz",
-      "integrity": "sha512-kPlBidsAj2S2rYEt9y+MOZHlTy6dvHQ3asquAGUY5L79BIiKKYVFXLtXyS0qlHXq5T4cZpv/z4faJwqfMLo+gA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/neocatecumenal/-/neocatecumenal-2.1.8.tgz",
+      "integrity": "sha512-45p0rx9w5Zw2wfiw8azTpsponf2TZo9KURFLB8p7h8guKQYa2KneWW9IXCHx3lrbAAQGwcmltkLeJ7lbt7ptVQ==",
       "license": "ISC"
     },
     "node_modules/node-abort-controller": {
@@ -10095,15 +10095,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.6.0.tgz",
-      "integrity": "sha512-SYCUykz+1cnl6Ugd8VUvtTQq5+j1Q7C0CtzKPjQ8JyA2ALh0EEJkMCS+KgdnvKW1lrxjtjCyJSHOOT236mENYg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.7.0.tgz",
+      "integrity": "sha512-vArg+4UqnQ13CVhc2WUosemwh6hr6cr6FY2uzDvCIFwH8pu8BXVv38PktoMLVjtX7sbYThxbnZF5YiR8sN2clw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.6.0",
-        "@prisma/engines": "6.6.0"
+        "@prisma/config": "6.7.0",
+        "@prisma/engines": "6.7.0"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ambrosio",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ambrosio",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@casl/ability": "^6.7.3",
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
-      "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1269,9 +1269,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1377,9 +1377,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
-      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
+      "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2484,6 +2484,28 @@
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
       "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
+      "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@nestjs/axios": {
       "version": "4.0.0",
@@ -5218,9 +5240,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.24.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
       "dev": true,
       "funding": [
         {
@@ -5238,10 +5260,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
+        "caniuse-lite": "^1.0.30001716",
+        "electron-to-chromium": "^1.5.149",
         "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5498,13 +5520,13 @@
       "license": "MIT"
     },
     "node_modules/class-validator": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
-      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
+      "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.11.8",
-        "libphonenumber-js": "^1.10.53",
+        "libphonenumber-js": "^1.11.1",
         "validator": "^13.9.0"
       }
     },
@@ -6133,9 +6155,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.148",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.148.tgz",
-      "integrity": "sha512-8uc1QXwwqayD4mblcsQYZqoi+cOc97A2XmKSBOIRbEAvbp6vrqmSYs4dHD2qVygUgn7Mi0qdKgPaJ9WC8cv63A==",
+      "version": "1.5.149",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.149.tgz",
+      "integrity": "sha512-UyiO82eb9dVOx8YO3ajDf9jz2kKyt98DEITRdeLPstOEuTlLzDA4Gyq5K9he71TQziU5jUVu2OAu5N48HmQiyQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6327,9 +6349,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
-      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
+      "version": "9.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
+      "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6339,11 +6361,12 @@
         "@eslint/config-helpers": "^0.2.1",
         "@eslint/core": "^0.13.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.25.1",
+        "@eslint/js": "9.26.0",
         "@eslint/plugin-kit": "^0.2.8",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
+        "@modelcontextprotocol/sdk": "^1.8.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -6367,7 +6390,8 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
+        "optionator": "^0.9.3",
+        "zod": "^3.24.2"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -6401,9 +6425,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.6.tgz",
-      "integrity": "sha512-mUcf7QG2Tjk7H055Jk0lGBjbgDnfrvqjhXh9t2xLMSCjZVcw9Rb1V6sVNXO0th3jgeO7zllWPTNRil3JW94TnQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.3.1.tgz",
+      "integrity": "sha512-vad9VWgEm9xaVXRNmb4aeOt0PWDc61IAdzghkbYQ2wavgax148iKoX1rNJcgkBGCipzLzOnHYVgL7xudM9yccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6632,6 +6656,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
+      "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
+      "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6729,6 +6776,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/external-editor": {
@@ -9418,9 +9481,9 @@
       "license": "MIT"
     },
     "node_modules/neocatecumenal": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/neocatecumenal/-/neocatecumenal-2.1.8.tgz",
-      "integrity": "sha512-45p0rx9w5Zw2wfiw8azTpsponf2TZo9KURFLB8p7h8guKQYa2KneWW9IXCHx3lrbAAQGwcmltkLeJ7lbt7ptVQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/neocatecumenal/-/neocatecumenal-2.1.9.tgz",
+      "integrity": "sha512-45ieOZ/wIiLDnApdrAgnSjgDhUJKaeM5xMRbL6qjM3ugfV2cVcX2GnPNQcBSRvBkjUjqpVkJgPXDjHblqhpj3g==",
       "license": "ISC"
     },
     "node_modules/node-abort-controller": {
@@ -9907,6 +9970,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -12403,6 +12476,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ambrosio",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "API Backend for Neocatecumenal Way",
   "author": {
     "name": "Leonardo Nascimento Cintra",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -280,8 +280,9 @@ async function main() {
   }
 
   async function cidade() {
-    const estadoId = (await prisma.estado.findFirst({ where: { sigla: 'MG' } }))
-      .id;
+    const estado = await prisma.estado.findFirst();
+    const estadoId = estado.id;
+
     await prisma.cidade.create({
       data: {
         nome: 'Ibiraci',

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,6 +17,7 @@ async function main() {
   await tipoEquipe();
   await etapa();
   await diocese();
+  await paroquia();
   await admin();
 
   async function admin() {
@@ -687,6 +688,31 @@ async function main() {
 
     console.log('---------------------------------');
     console.log('Diocese preenchido com sucesso!');
+  }
+
+  async function paroquia() {
+    const cidade = await prisma.cidade.findFirst();
+    const endereco = await prisma.endereco.create({
+      data: {
+        bairro: faker.location.street(),
+        cep: faker.location.zipCode('########'),
+        logradouro: faker.location.street(),
+        numero: faker.number.int({ min: 1, max: 9000 }).toString(),
+        observacao: faker.location.streetAddress(),
+        cidadeId: cidade.id,
+      },
+    });
+
+    await prisma.paroquia.create({
+      data: {
+        descricao: 'Paroquia Nossa Senhora Aparecida (Seed)',
+        dioceseId: 1,
+        enderecoId: endereco.id,
+      },
+    });
+
+    console.log('---------------------------------');
+    console.log('Paroquia preenchida com sucesso!');
   }
 }
 

--- a/src/casl/casl-ability/casl-ability.service.ts
+++ b/src/casl/casl-ability/casl-ability.service.ts
@@ -1,7 +1,7 @@
 import { AbilityBuilder, PureAbility } from '@casl/ability';
 import { createPrismaAbility, PrismaQuery, Subjects } from '@casl/prisma';
 import { Injectable, Scope } from '@nestjs/common';
-import { diocese, localidade, pessoa, user } from '@prisma/client';
+import { diocese, localidade, paroquia, pessoa, user } from '@prisma/client';
 import { ROLE_ENUM } from 'src/commons/enums/enums';
 
 export type PermActions = 'manage' | 'create' | 'read' | 'update' | 'delete';
@@ -11,6 +11,7 @@ export type PermissionResource =
       pessoa: pessoa;
       user: user;
       diocese: diocese;
+      paroquia: paroquia;
       localidade: localidade;
     }>
   | 'all';
@@ -38,6 +39,7 @@ const rolePermissionsMap: Record<ROLE_ENUM, DefinePermissions> = {
   NAO_IDENTIFICADO(user, { cannot }) {
     cannot('read', 'pessoa');
     cannot('read', 'diocese');
+    cannot('read', 'paroquia');
     cannot('read', 'localidade');
   },
   CATEQUISTA_NACIONAL: grantReadPessoaDiocese,

--- a/src/configuracoes/cidade/cidade.service.ts
+++ b/src/configuracoes/cidade/cidade.service.ts
@@ -44,7 +44,7 @@ export class CidadeService {
     );
 
     if (!uf) {
-      throw new NotFoundException('Estado não encontrado');
+      throw new NotFoundException(`Estado ${createCidadeDto.estado.sigla} não encontrado`);
     }
 
     return this.prisma.cidade.create({

--- a/src/configuracoes/cidade/cidade.service.ts
+++ b/src/configuracoes/cidade/cidade.service.ts
@@ -44,7 +44,7 @@ export class CidadeService {
     );
 
     if (!uf) {
-      throw new NotFoundException(`Estado ${createCidadeDto.estado.sigla} não encontrado`);
+      throw new NotFoundException('Estado não encontrado');
     }
 
     return this.prisma.cidade.create({

--- a/src/configuracoes/estado/estado.service.ts
+++ b/src/configuracoes/estado/estado.service.ts
@@ -41,15 +41,24 @@ export class EstadoService {
   }
 
   findAll() {
-    return `This action returns all estado`;
+    return this.prisma.estado.findMany({
+      include: {
+        pais: true,
+      },
+    });
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} estado`;
+    return this.prisma.estado.findUniqueOrThrow({
+      where: { id },
+      include: {
+        pais: true,
+      },
+    });
   }
 
-  findBySigla(sigla: string) {
-    return this.prisma.estado.findFirstOrThrow({
+  async findBySigla(sigla: string) {
+    return await this.prisma.estado.findFirstOrThrow({
       where: { sigla },
     });
   }

--- a/src/diocese/diocese.module.ts
+++ b/src/diocese/diocese.module.ts
@@ -8,5 +8,6 @@ import { TipoDioceseModule } from 'src/configuracoes/tipo-diocese/tipo-diocese.m
   controllers: [DioceseController],
   providers: [DioceseService],
   imports: [TipoDioceseModule, EnderecoModule],
+  exports: [DioceseService],
 })
 export class DioceseModule {}

--- a/src/diocese/diocese.service.ts
+++ b/src/diocese/diocese.service.ts
@@ -16,6 +16,7 @@ import { TipoDioceseService } from 'src/configuracoes/tipo-diocese/tipo-diocese.
 import { ENDERECO_INCLUDE } from 'src/commons/constants/constants';
 import { Diocese } from 'neocatecumenal';
 import { serializeEndereco } from 'src/commons/utils/serializers/serializerEndereco';
+import { DIOCESE_SELECT } from 'src/prisma/selects/diocese.select';
 
 @Injectable()
 export class DioceseService {
@@ -51,10 +52,7 @@ export class DioceseService {
             tipoDioceseId: tipoDiocese.id,
             enderecoId: endereco.id,
           },
-          include: {
-            endereco: ENDERECO_INCLUDE,
-            tipoDiocese: true,
-          },
+          select: DIOCESE_SELECT,
         });
       });
 
@@ -72,17 +70,13 @@ export class DioceseService {
     const where = this.asPermissions();
     const results = await this.prisma.diocese.findMany({
       where,
-      include: {
-        tipoDiocese: true,
-        endereco: ENDERECO_INCLUDE,
-      },
+      select: DIOCESE_SELECT,
     });
 
     return results.map((result) => this.serializeResponse(result));
   }
 
   async findOne(id: number): Promise<Diocese> {
-    // TODO: apos adicionar diocese no npm "neocatecumenal" setar o retorno da promise aqui Promise<Diocese>
     const wherePermissions = this.asPermissions();
     const diocese = await this.prisma.diocese.findFirstOrThrow({
       where: {
@@ -90,19 +84,7 @@ export class DioceseService {
       },
       include: {
         tipoDiocese: true,
-        endereco: {
-          include: {
-            cidade: {
-              include: {
-                estado: {
-                  include: {
-                    pais: true,
-                  },
-                },
-              },
-            },
-          },
-        },
+        endereco: ENDERECO_INCLUDE,
       },
     });
 

--- a/src/paroquia/dto/create-paroquia.dto.ts
+++ b/src/paroquia/dto/create-paroquia.dto.ts
@@ -1,1 +1,32 @@
-export class CreateParoquiaDto {}
+import { Type } from 'class-transformer';
+import {
+  IsNumber,
+  IsObject,
+  IsPositive,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { CreateEnderecoDto } from 'src/endereco/dto/create-endereco.dto';
+
+class DioceseDto {
+  @IsNumber()
+  @IsPositive()
+  id: number;
+}
+
+export class CreateParoquiaDto {
+  @IsString()
+  @MaxLength(50)
+  descricao: string;
+
+  @IsObject()
+  @ValidateNested({ each: true })
+  @Type(() => DioceseDto)
+  diocese: DioceseDto;
+
+  @IsObject()
+  @ValidateNested({ each: true })
+  @Type(() => CreateEnderecoDto)
+  endereco: CreateEnderecoDto;
+}

--- a/src/paroquia/dto/findAll-paroquia.dto.ts
+++ b/src/paroquia/dto/findAll-paroquia.dto.ts
@@ -1,0 +1,10 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class FindAllParoquiasQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'dioceseId deve ser um número inteiro válido' })
+  @Min(1, { message: 'dioceseId deve ser maior que zero' })
+  dioceseId?: number;
+}

--- a/src/paroquia/dto/update-paroquia.dto.ts
+++ b/src/paroquia/dto/update-paroquia.dto.ts
@@ -1,4 +1,11 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateParoquiaDto } from './create-paroquia.dto';
+import { ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { UpdateEnderecoDto } from 'src/endereco/dto/update-endereco.dto';
 
-export class UpdateParoquiaDto extends PartialType(CreateParoquiaDto) {}
+export class UpdateParoquiaDto extends PartialType(CreateParoquiaDto) {
+  @ValidateNested({ each: true })
+  @Type(() => UpdateEnderecoDto)
+  endereco: UpdateEnderecoDto;
+}

--- a/src/paroquia/paroquia.controller.spec.ts
+++ b/src/paroquia/paroquia.controller.spec.ts
@@ -4,18 +4,38 @@ import { ParoquiaService } from './paroquia.service';
 import { PrismaService } from 'src/prisma.service';
 import { JwtService } from '@nestjs/jwt';
 import { CaslAbilityService } from 'src/casl/casl-ability/casl-ability.service';
+import { EnderecoService } from 'src/endereco/endereco.service';
+import { DioceseService } from 'src/diocese/diocese.service';
+import { TipoDioceseService } from 'src/configuracoes/tipo-diocese/tipo-diocese.service';
+import { CidadeService } from 'src/configuracoes/cidade/cidade.service';
+import { EstadoService } from 'src/configuracoes/estado/estado.service';
+import { PaisService } from 'src/configuracoes/pais/pais.service';
+import { HttpModule } from '@nestjs/axios';
 
 describe('ParoquiaController', () => {
   let controller: ParoquiaController;
   let prismaService: PrismaService;
+  let enderecoService: EnderecoService;
+  let dioceseService: DioceseService;
+  let tipoDioceseService: TipoDioceseService;
+  let cidadeService: CidadeService;
+  let estadoService: EstadoService;
+  let paisService: PaisService;
   let jwtService: JwtService;
   let abilityService: CaslAbilityService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
       controllers: [ParoquiaController],
       providers: [
         ParoquiaService,
+        DioceseService,
+        EnderecoService,
+        TipoDioceseService,
+        CidadeService,
+        EstadoService,
+        PaisService,
         JwtService,
         CaslAbilityService,
         {
@@ -30,6 +50,12 @@ describe('ParoquiaController', () => {
 
     controller = module.get<ParoquiaController>(ParoquiaController);
     prismaService = module.get<PrismaService>(PrismaService);
+    enderecoService = module.get<EnderecoService>(EnderecoService);
+    tipoDioceseService = module.get<TipoDioceseService>(TipoDioceseService);
+    cidadeService = module.get<CidadeService>(CidadeService);
+    estadoService = module.get<EstadoService>(EstadoService);
+    paisService = module.get<PaisService>(PaisService);
+    dioceseService = module.get<DioceseService>(DioceseService);
     jwtService = module.get<JwtService>(JwtService);
     abilityService =
       await module.resolve<CaslAbilityService>(CaslAbilityService);
@@ -40,5 +66,11 @@ describe('ParoquiaController', () => {
     expect(prismaService).toBeDefined();
     expect(jwtService).toBeDefined();
     expect(abilityService).toBeDefined();
+    expect(dioceseService).toBeDefined();
+    expect(enderecoService).toBeDefined();
+    expect(tipoDioceseService).toBeDefined();
+    expect(cidadeService).toBeDefined();
+    expect(estadoService).toBeDefined();
+    expect(paisService).toBeDefined();
   });
 });

--- a/src/paroquia/paroquia.controller.ts
+++ b/src/paroquia/paroquia.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { ParoquiaService } from './paroquia.service';
 import { CreateParoquiaDto } from './dto/create-paroquia.dto';
@@ -14,6 +15,7 @@ import { UpdateParoquiaDto } from './dto/update-paroquia.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from 'src/auth/auth.guard';
 import { RoleGuard } from 'src/auth/role/role.guard';
+import { FindAllParoquiasQueryDto } from './dto/findAll-paroquia.dto';
 
 @ApiTags('Paróquias')
 @UseGuards(AuthGuard, RoleGuard)
@@ -27,8 +29,8 @@ export class ParoquiaController {
   }
 
   @Get()
-  findAll() {
-    return this.paroquiaService.findAll();
+  findAll(@Query() query: FindAllParoquiasQueryDto) {
+    return this.paroquiaService.findAll(+query.dioceseId);
   }
 
   @Get(':id')

--- a/src/paroquia/paroquia.module.ts
+++ b/src/paroquia/paroquia.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ParoquiaService } from './paroquia.service';
 import { ParoquiaController } from './paroquia.controller';
+import { DioceseModule } from 'src/diocese/diocese.module';
+import { EnderecoModule } from 'src/endereco/endereco.module';
 
 @Module({
   controllers: [ParoquiaController],
   providers: [ParoquiaService],
+  imports: [DioceseModule, EnderecoModule],
 })
 export class ParoquiaModule {}

--- a/src/paroquia/paroquia.service.spec.ts
+++ b/src/paroquia/paroquia.service.spec.ts
@@ -1,15 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ParoquiaService } from './paroquia.service';
 import { PrismaService } from 'src/prisma.service';
+import { EnderecoService } from 'src/endereco/endereco.service';
+import { DioceseService } from 'src/diocese/diocese.service';
+import { TipoDioceseService } from 'src/configuracoes/tipo-diocese/tipo-diocese.service';
+import { CidadeService } from 'src/configuracoes/cidade/cidade.service';
+import { EstadoService } from 'src/configuracoes/estado/estado.service';
+import { PaisService } from 'src/configuracoes/pais/pais.service';
+import { HttpModule } from '@nestjs/axios';
+import { CaslAbilityService } from 'src/casl/casl-ability/casl-ability.service';
 
 describe('ParoquiaService', () => {
   let service: ParoquiaService;
   let prismaService: PrismaService;
+  let enderecoService: EnderecoService;
+  let dioceseServce: DioceseService;
+  let tipoDioceseService: TipoDioceseService;
+  let cidadeService: CidadeService;
+  let estadoService: EstadoService;
+  let paisService: PaisService;
+  let abilityService: CaslAbilityService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
       providers: [
         ParoquiaService,
+        DioceseService,
+        EnderecoService,
+        TipoDioceseService,
+        CidadeService,
+        EstadoService,
+        PaisService,
+        CaslAbilityService,
         {
           provide: PrismaService,
           useValue: {
@@ -21,11 +44,26 @@ describe('ParoquiaService', () => {
     }).compile();
 
     service = module.get<ParoquiaService>(ParoquiaService);
+    enderecoService = module.get<EnderecoService>(EnderecoService);
+    tipoDioceseService = module.get<TipoDioceseService>(TipoDioceseService);
+    dioceseServce = module.get<DioceseService>(DioceseService);
+    cidadeService = module.get<CidadeService>(CidadeService);
+    estadoService = module.get<EstadoService>(EstadoService);
+    paisService = module.get<PaisService>(PaisService);
     prismaService = module.get<PrismaService>(PrismaService);
+    abilityService =
+      await module.resolve<CaslAbilityService>(CaslAbilityService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
     expect(prismaService).toBeDefined();
+    expect(enderecoService).toBeDefined();
+    expect(dioceseServce).toBeDefined();
+    expect(cidadeService).toBeDefined();
+    expect(estadoService).toBeDefined();
+    expect(paisService).toBeDefined();
+    expect(tipoDioceseService).toBeDefined();
+    expect(abilityService).toBeDefined();
   });
 });

--- a/src/paroquia/paroquia.service.spec.ts
+++ b/src/paroquia/paroquia.service.spec.ts
@@ -14,7 +14,7 @@ describe('ParoquiaService', () => {
   let service: ParoquiaService;
   let prismaService: PrismaService;
   let enderecoService: EnderecoService;
-  let dioceseServce: DioceseService;
+  let dioceseService: DioceseService;
   let tipoDioceseService: TipoDioceseService;
   let cidadeService: CidadeService;
   let estadoService: EstadoService;
@@ -29,9 +29,9 @@ describe('ParoquiaService', () => {
         DioceseService,
         EnderecoService,
         TipoDioceseService,
-        CidadeService,
-        EstadoService,
         PaisService,
+        EstadoService,
+        CidadeService,
         CaslAbilityService,
         {
           provide: PrismaService,
@@ -46,7 +46,7 @@ describe('ParoquiaService', () => {
     service = module.get<ParoquiaService>(ParoquiaService);
     enderecoService = module.get<EnderecoService>(EnderecoService);
     tipoDioceseService = module.get<TipoDioceseService>(TipoDioceseService);
-    dioceseServce = module.get<DioceseService>(DioceseService);
+    dioceseService = module.get<DioceseService>(DioceseService);
     cidadeService = module.get<CidadeService>(CidadeService);
     estadoService = module.get<EstadoService>(EstadoService);
     paisService = module.get<PaisService>(PaisService);
@@ -59,7 +59,7 @@ describe('ParoquiaService', () => {
     expect(service).toBeDefined();
     expect(prismaService).toBeDefined();
     expect(enderecoService).toBeDefined();
-    expect(dioceseServce).toBeDefined();
+    expect(dioceseService).toBeDefined();
     expect(cidadeService).toBeDefined();
     expect(estadoService).toBeDefined();
     expect(paisService).toBeDefined();

--- a/src/paroquia/paroquia.service.ts
+++ b/src/paroquia/paroquia.service.ts
@@ -1,29 +1,119 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
 import { CreateParoquiaDto } from './dto/create-paroquia.dto';
 import { UpdateParoquiaDto } from './dto/update-paroquia.dto';
 import { PrismaService } from 'src/prisma.service';
+import { DioceseService } from 'src/diocese/diocese.service';
+import { EnderecoService } from 'src/endereco/endereco.service';
+import { CaslAbilityService } from 'src/casl/casl-ability/casl-ability.service';
+import { accessibleBy } from '@casl/prisma';
+import { Paroquia } from 'neocatecumenal';
+import { serializeEndereco } from 'src/commons/utils/serializers/serializerEndereco';
+import { PAROQUIA_SELECT } from 'src/prisma/selects/paroquia.select';
 
 @Injectable()
 export class ParoquiaService {
-  constructor(private prisma: PrismaService) {}
+  private readonly logger = new Logger(ParoquiaService.name);
 
-  create(createParoquiaDto: CreateParoquiaDto) {
-    return 'This action adds a new paroquia';
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly dioceseService: DioceseService,
+    private readonly enderecoService: EnderecoService,
+    private readonly abilityService: CaslAbilityService,
+  ) {}
+
+  async create(createParoquiaDto: CreateParoquiaDto) {
+    await this.dioceseService.findOne(createParoquiaDto.diocese.id);
+
+    const enderecoComObservacao = {
+      ...createParoquiaDto.endereco,
+      observacao: `End. da paróquia ${createParoquiaDto.descricao}.`,
+    };
+
+    try {
+      const result = await this.prisma.$transaction(async (transaction) => {
+        const endereco = await this.enderecoService.create(
+          enderecoComObservacao,
+          transaction,
+        );
+        return await transaction.paroquia.create({
+          data: {
+            descricao: createParoquiaDto.descricao,
+            dioceseId: createParoquiaDto.diocese.id,
+            enderecoId: endereco.id,
+          },
+          select: PAROQUIA_SELECT,
+        });
+      });
+
+      return this.serializeResponse(result);
+    } catch (error) {
+      this.logger.error(error);
+      throw new HttpException(
+        `Ocorreu um erro ao cadastrar a paroquia ${createParoquiaDto.descricao}. Erro: ${error}`,
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
   }
 
-  findAll() {
-    return `This action returns all paroquia`;
+  async findAll() {
+    const where = this.asPermissions();
+    const results = await this.prisma.paroquia.findMany({
+      where,
+      select: PAROQUIA_SELECT,
+    });
+
+    return results.map((result) => this.serializeResponse(result));
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} paroquia`;
+    const wherePermissions = this.asPermissions();
+    return this.prisma.paroquia.findFirstOrThrow({
+      where: {
+        AND: [{ id }, wherePermissions],
+      },
+      select: PAROQUIA_SELECT,
+    });
   }
 
   update(id: number, updateParoquiaDto: UpdateParoquiaDto) {
-    return `This action updates a #${id} paroquia`;
+    return `This action updates a #${id} paroquia ${updateParoquiaDto.descricao}`;
   }
 
   remove(id: number) {
     return `This action removes a #${id} paroquia`;
+  }
+
+  private asPermissions() {
+    const { ability } = this.abilityService;
+    if (!ability.can('read', 'paroquia')) {
+      throw new ForbiddenException(
+        'Você não tem permissão para listar paroquias',
+      );
+    }
+    return accessibleBy(ability, 'read').paroquia;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serializeResponse(paroquia: any): Paroquia {
+    return {
+      id: paroquia.id,
+      descricao: paroquia.descricao,
+      endereco: serializeEndereco(paroquia.endereco),
+      diocese: {
+        id: paroquia.diocese.id,
+        descricao: paroquia.diocese.descricao,
+        endereco: serializeEndereco(paroquia.diocese.endereco),
+        tipoDiocese: {
+          id: paroquia.diocese.tipoDiocese.id,
+          descricao: paroquia.diocese.tipoDiocese.descricao,
+        },
+      },
+    };
   }
 }

--- a/src/paroquia/paroquia.service.ts
+++ b/src/paroquia/paroquia.service.ts
@@ -62,8 +62,16 @@ export class ParoquiaService {
     }
   }
 
-  async findAll() {
-    const where = this.asPermissions();
+  async findAll(dioceseId?: number) {
+    const permissionWhere = this.asPermissions();
+    const where = {
+      ...permissionWhere,
+    };
+
+    if (dioceseId) {
+      where.dioceseId = dioceseId;
+    }
+
     const results = await this.prisma.paroquia.findMany({
       where,
       select: PAROQUIA_SELECT,

--- a/src/paroquia/paroquia.service.ts
+++ b/src/paroquia/paroquia.service.ts
@@ -56,7 +56,7 @@ export class ParoquiaService {
     } catch (error) {
       this.logger.error(error);
       throw new HttpException(
-        `Ocorreu um erro ao cadastrar a paroquia ${createParoquiaDto.descricao}. Erro: ${error}`,
+        `Ocorreu um erro ao cadastrar a paroquia. Por favor tente novamente mais tarde. Erro: ${error}`,
         HttpStatus.BAD_GATEWAY,
       );
     }

--- a/src/prisma/selects/diocese.select.ts
+++ b/src/prisma/selects/diocese.select.ts
@@ -1,0 +1,15 @@
+import { ENDERECO_SELECT } from "./endereco.select";
+
+export const DIOCESE_SELECT = {
+  id: true,
+  descricao: true,
+  endereco: {
+    select: ENDERECO_SELECT,
+  },
+  tipoDiocese: {
+    select: {
+      id: true,
+      descricao: true,
+    },
+  },
+};

--- a/src/prisma/selects/endereco.select.ts
+++ b/src/prisma/selects/endereco.select.ts
@@ -1,0 +1,27 @@
+export const ENDERECO_SELECT = {
+  id: true,
+  cep: true,
+  logradouro: true,
+  bairro: true,
+  numero: true,
+  observacao: true,
+  cidade: {
+    select: {
+      id: true,
+      nome: true,
+      estado: {
+        select: {
+          id: true,
+          sigla: true,
+          nome: true,
+          pais: {
+            select: {
+              id: true,
+              nome: true,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/prisma/selects/paroquia.select.ts
+++ b/src/prisma/selects/paroquia.select.ts
@@ -1,0 +1,13 @@
+import { DIOCESE_SELECT } from './diocese.select';
+import { ENDERECO_SELECT } from './endereco.select';
+
+export const PAROQUIA_SELECT = {
+  id: true,
+  descricao: true,
+  endereco: {
+    select: ENDERECO_SELECT,
+  },
+  diocese: {
+    select: DIOCESE_SELECT,
+  },
+};

--- a/test/diocese.e2e-spec.ts
+++ b/test/diocese.e2e-spec.ts
@@ -231,12 +231,12 @@ describe('DioceseController (e2e)', () => {
       });
   });
 
-  it(`/${principal} (PATCH) - 200 | deve atualizar uma diocese com campos válidos`, async () => {
+  it(`/${principal}/:id (PATCH) - 200 | deve atualizar uma diocese com campos válidos`, async () => {
     const dioceseData = {
       descricao: faker.company.name(),
       tipoDiocese: { id: 2, descricao: 'Diocese' },
       endereco: {
-        id: 3,
+        id: 1,
         cep: faker.location.zipCode('########'),
         logradouro: faker.location.streetAddress(),
         numero: '1226',
@@ -247,7 +247,7 @@ describe('DioceseController (e2e)', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/${principal}/2`)
+      .patch(`/${principal}/1`)
       .set('Authorization', `Bearer ${token}`)
       .set('Content-Type', 'application/json')
       .send(dioceseData)

--- a/test/diocese.e2e-spec.ts
+++ b/test/diocese.e2e-spec.ts
@@ -120,7 +120,7 @@ describe('DioceseController (e2e)', () => {
         numero: '32',
         bairro: faker.location.secondaryAddress(),
         UF: 'SP',
-        cidade: 'Nuporanga',
+        cidade: faker.location.city(),
       },
     };
 

--- a/test/diocese.e2e-spec.ts
+++ b/test/diocese.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import { setupTestModule } from '../test-setup';
+import { setupTestModule } from './test-setup';
 import request from 'supertest';
 import { faker } from '@faker-js/faker/.';
 
@@ -236,7 +236,7 @@ describe('DioceseController (e2e)', () => {
       descricao: faker.company.name(),
       tipoDiocese: { id: 2, descricao: 'Diocese' },
       endereco: {
-        id: 2,
+        id: 3,
         cep: faker.location.zipCode('########'),
         logradouro: faker.location.streetAddress(),
         numero: '1226',

--- a/test/paroquia.e2e-spec.ts
+++ b/test/paroquia.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { setupTestModule } from './test-setup';
 import request from 'supertest';
+import { faker } from '@faker-js/faker/.';
 
 describe('ParoquiaController (e2e)', () => {
   let app: INestApplication;
@@ -136,197 +137,212 @@ describe('ParoquiaController (e2e)', () => {
       });
   });
 
-  // it(`/${principal} (POST) - 201 | deve criar uma diocese com campos válidos`, async () => {
-  //   const dioceseData = {
-  //     descricao: 'Jenkins, Mosciski and Marvin',
-  //     tipoDiocese: { id: 2, descricao: 'Diocese' },
-  //     endereco: {
-  //       cep: faker.location.zipCode('########'),
-  //       logradouro: faker.location.streetAddress(),
-  //       numero: '32',
-  //       bairro: faker.location.secondaryAddress(),
-  //       UF: 'SP',
-  //       cidade: 'Nuporanga',
-  //     },
-  //   };
+  it(`/${principal} (POST) - 201 | deve criar uma paroquia com campos válidos`, async () => {
+    const dioceseData = {
+      descricao: faker.company.name(),
+      diocese: { id: 1 },
+      endereco: {
+        cep: faker.location.zipCode('########'),
+        logradouro: faker.location.streetAddress(),
+        numero: '32',
+        bairro: faker.location.secondaryAddress(),
+        UF: 'SP',
+        cidade: 'Nuporanga',
+      },
+    };
 
-  //   const response = await request(app.getHttpServer())
-  //     .post(`/${principal}`)
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .set('Content-Type', 'application/json')
-  //     .send(dioceseData)
-  //     .expect(201);
+    const response = await request(app.getHttpServer())
+      .post(`/${principal}`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send(dioceseData)
+      .expect(201);
 
-  //   expect(response.body.data).toHaveProperty('id');
-  //   expect(response.body.data.descricao).toBe(dioceseData.descricao);
-  //   expect(response.body.data.tipoDiocese.id).toBe(dioceseData.tipoDiocese.id);
-  //   expect(response.body.data.endereco.cep).toBe(dioceseData.endereco.cep);
-  //   expect(response.body.data.endereco.bairro).toBe(
-  //     dioceseData.endereco.bairro,
-  //   );
-  //   expect(response.body.data.endereco.logradouro).toBe(
-  //     dioceseData.endereco.logradouro,
-  //   );
-  //   expect(response.body.data.endereco.numero).toBe(
-  //     dioceseData.endereco.numero,
-  //   );
-  //   expect(response.body.data.endereco.cidade.nome).toBe(
-  //     dioceseData.endereco.cidade,
-  //   );
-  //   expect(response.body.data.endereco.cidade.estado.sigla).toBe(
-  //     dioceseData.endereco.UF,
-  //   );
-  //   expect(response.body.data.endereco.cidade.estado.pais.nome).toBe('Brasil');
-  //   expect(response.body.data.endereco.observacao).toBeDefined();
-  // });
+    expect(response.body.data).toHaveProperty('id');
+    expect(response.body.data.descricao).toBe(dioceseData.descricao);
+    expect(response.body.data.diocese.id).toBe(dioceseData.diocese.id);
+    expect(response.body.data.endereco.cep).toBe(dioceseData.endereco.cep);
+    expect(response.body.data.endereco.bairro).toBe(
+      dioceseData.endereco.bairro,
+    );
+    expect(response.body.data.endereco.logradouro).toBe(
+      dioceseData.endereco.logradouro,
+    );
+    expect(response.body.data.endereco.numero).toBe(
+      dioceseData.endereco.numero,
+    );
+    expect(response.body.data.endereco.cidade.nome).toBe(
+      dioceseData.endereco.cidade,
+    );
+    expect(response.body.data.endereco.cidade.estado.sigla).toBe(
+      dioceseData.endereco.UF,
+    );
+    expect(response.body.data.endereco.cidade.estado.pais.nome).toBe('Brasil');
+    expect(response.body.data.endereco.observacao).toBeDefined();
+  });
 
-  // it(`/${principal} (POST) - 404 | nao deve criar uma diocese tipo diocese invalida`, async () => {
-  //   const dioceseData = {
-  //     descricao: 'Jenkins, Mosciski and Marvin',
-  //     tipoDiocese: { id: 489, descricao: 'Diocese Mentira' },
-  //     endereco: {
-  //       cep: faker.location.zipCode('########'),
-  //       logradouro: faker.location.streetAddress(),
-  //       numero: '32',
-  //       bairro: faker.location.secondaryAddress(),
-  //       UF: 'SP',
-  //       cidade: 'Nuporanga',
-  //     },
-  //   };
+  it(`/${principal} (POST) - 404 | nao deve criar uma paroquia quando diocese invalida`, async () => {
+    const dioceseData = {
+      descricao: faker.company.name(),
+      diocese: { id: 489 },
+      endereco: {
+        cep: faker.location.zipCode('########'),
+        logradouro: faker.location.streetAddress(),
+        numero: '32',
+        bairro: faker.location.secondaryAddress(),
+        UF: 'SP',
+        cidade: 'Nuporanga',
+      },
+    };
 
-  //   await request(app.getHttpServer())
-  //     .post(`/${principal}`)
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .set('Content-Type', 'application/json')
-  //     .send(dioceseData)
-  //     .expect(404)
-  //     .expect((res) => {
-  //       expect(res.body.message).toBe(`Tipo de diocese não encontrada`);
-  //       expect(res.body.error).toBe('Not Found');
-  //       expect(res.body.statusCode).toBe(404);
-  //     });
-  // });
+    await request(app.getHttpServer())
+      .post(`/${principal}`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send(dioceseData)
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(
+          `O registro de 'Diocese' não foi encontrado.`,
+        );
+        expect(res.body.statusCode).toBe(404);
+      });
+  });
 
-  // it(`/${principal} (POST) - 400 | nao deve criar uma diocese tipo diocese null`, async () => {
-  //   const dioceseData = {
-  //     descricao: faker.company.name(),
-  //     endereco: {
-  //       cep: faker.location.zipCode('########'),
-  //       logradouro: faker.location.streetAddress(),
-  //       numero: '32',
-  //       bairro: faker.location.secondaryAddress(),
-  //       UF: 'SP',
-  //       cidade: 'Nuporanga',
-  //     },
-  //   };
+  it(`/${principal} (POST) - 400 | nao deve criar uma paroquia quando diocese null`, async () => {
+    const dioceseData = {
+      descricao: faker.company.name(),
+      endereco: {
+        cep: faker.location.zipCode('########'),
+        logradouro: faker.location.streetAddress(),
+        numero: '32',
+        bairro: faker.location.secondaryAddress(),
+        UF: 'SP',
+        cidade: 'Nuporanga',
+      },
+    };
 
-  //   await request(app.getHttpServer())
-  //     .post(`/${principal}`)
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .set('Content-Type', 'application/json')
-  //     .send(dioceseData)
-  //     .expect(400)
-  //     .expect((res) => {
-  //       expect(res.body.message[0]).toBe(`tipoDiocese must be an object`);
-  //       expect(res.body.error).toBe('Bad Request');
-  //       expect(res.body.statusCode).toBe(400);
-  //     });
-  // });
+    await request(app.getHttpServer())
+      .post(`/${principal}`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send(dioceseData)
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.message[0]).toBe(`diocese must be an object`);
+        expect(res.body.error).toBe('Bad Request');
+        expect(res.body.statusCode).toBe(400);
+      });
+  });
 
-  // it(`/${principal} (POST) - 401 | deve falhar sem autenticação`, async () => {
-  //   await request(app.getHttpServer())
-  //     .post(`/${principal}`)
-  //     .send({ descricao: 'Diocese sem token' })
-  //     .expect(401)
-  //     .expect((res) => {
-  //       expect(res.body.message).toBe('Invalid or missing token');
-  //       expect(res.body.error).toBe('Unauthorized');
-  //       expect(res.body.statusCode).toBe(401);
-  //     });
-  // });
+  it(`/${principal} (POST) - 401 | deve falhar sem autenticação`, async () => {
+    await request(app.getHttpServer())
+      .post(`/${principal}`)
+      .send({ descricao: 'Diocese sem token' })
+      .expect(401)
+      .expect((res) => {
+        expect(res.body.message).toBe('Invalid or missing token');
+        expect(res.body.error).toBe('Unauthorized');
+        expect(res.body.statusCode).toBe(401);
+      });
+  });
 
-  // it(`/${principal}/1 (PATCH) - 401 | deve falhar sem autenticação by id`, async () => {
-  //   await request(app.getHttpServer())
-  //     .patch(`/${principal}/1`)
-  //     .send({ descricao: 'Diocese sem token' })
-  //     .expect(401)
-  //     .expect((res) => {
-  //       expect(res.body.message).toBe('Invalid or missing token');
-  //       expect(res.body.error).toBe('Unauthorized');
-  //       expect(res.body.statusCode).toBe(401);
-  //     });
-  // });
+  it(`/${principal}/1 (PATCH) - 401 | deve falhar sem autenticação by id`, async () => {
+    await request(app.getHttpServer())
+      .patch(`/${principal}/1`)
+      .send({ descricao: 'Diocese sem token' })
+      .expect(401)
+      .expect((res) => {
+        expect(res.body.message).toBe('Invalid or missing token');
+        expect(res.body.error).toBe('Unauthorized');
+        expect(res.body.statusCode).toBe(401);
+      });
+  });
 
-  // it(`/${principal} (PATCH) - 200 | deve atualizar uma diocese com campos válidos`, async () => {
-  //   const dioceseData = {
-  //     descricao: faker.company.name(),
-  //     tipoDiocese: { id: 2, descricao: 'Diocese' },
-  //     endereco: {
-  //       id: 2,
-  //       cep: faker.location.zipCode('########'),
-  //       logradouro: faker.location.streetAddress(),
-  //       numero: '1226',
-  //       bairro: faker.location.secondaryAddress(),
-  //       cidade: faker.location.city(),
-  //       UF: 'SP',
-  //     },
-  //   };
+  it(`/${principal}/4848 (PATCH) - 404 | deve falhar quando diocese nao existe`, async () => {
+    await request(app.getHttpServer())
+      .patch(`/${principal}/4848`)
+      .set('Content-Type', 'application/json')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ descricao: 'Diocese sem token' })
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(
+          "O registro de 'Paroquia' não foi encontrado.",
+        );
+      });
+  });
 
-  //   const response = await request(app.getHttpServer())
-  //     .patch(`/${principal}/2`)
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .set('Content-Type', 'application/json')
-  //     .send(dioceseData)
-  //     .expect(200);
+  it(`/${principal} (PATCH) - 200 | deve atualizar uma paroquia com campos válidos`, async () => {
+    const dioceseData = {
+      descricao: faker.company.name(),
+      diocese: { id: 1 },
+      endereco: {
+        id: 2,
+        cep: faker.location.zipCode('########'),
+        logradouro: faker.location.streetAddress(),
+        numero: '4848',
+        bairro: faker.location.secondaryAddress(),
+        cidade: faker.location.city(),
+        UF: 'MG',
+      },
+    };
 
-  //   expect(response.body.data).toHaveProperty('id');
-  //   expect(response.body.data.descricao).toBe(dioceseData.descricao);
-  //   expect(response.body.data.tipoDiocese.id).toBe(dioceseData.tipoDiocese.id);
-  //   expect(response.body.data.endereco.cep).toBe(dioceseData.endereco.cep);
-  //   expect(response.body.data.endereco.bairro).toBe(
-  //     dioceseData.endereco.bairro,
-  //   );
-  //   expect(response.body.data.endereco.numero).toBe(
-  //     dioceseData.endereco.numero,
-  //   );
-  //   expect(response.body.data.endereco.logradouro).toBe(
-  //     dioceseData.endereco.logradouro,
-  //   );
-  //   expect(response.body.data.endereco.cidade.nome).toBe(
-  //     dioceseData.endereco.cidade,
-  //   );
-  //   expect(response.body.data.endereco.cidade.estado.sigla).toBe(
-  //     dioceseData.endereco.UF,
-  //   );
-  // });
+    const response = await request(app.getHttpServer())
+      .patch(`/${principal}/1`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send(dioceseData)
+      .expect(200);
 
-  // it(`/${principal} (PATCH) - 404 | não deve atualizar uma diocese com id endereco de outra diocese`, async () => {
-  //   const dioceseData = {
-  //     descricao: faker.company.name(),
-  //     tipoDiocese: { id: 2, descricao: 'Diocese' },
-  //     endereco: {
-  //       id: 9874,
-  //       cep: faker.location.zipCode('########'),
-  //       logradouro: faker.location.streetAddress(),
-  //       numero: '1226',
-  //       bairro: faker.location.secondaryAddress(),
-  //       cidade: faker.location.city(),
-  //       UF: 'SP',
-  //     },
-  //   };
+    expect(response.body.data).toHaveProperty('id');
+    expect(response.body.data.descricao).toBe(dioceseData.descricao);
+    expect(response.body.data.diocese.id).toBe(dioceseData.diocese.id);
+    expect(response.body.data.endereco.cep).toBe(dioceseData.endereco.cep);
+    expect(response.body.data.endereco.bairro).toBe(
+      dioceseData.endereco.bairro,
+    );
+    expect(response.body.data.endereco.numero).toBe(
+      dioceseData.endereco.numero,
+    );
+    expect(response.body.data.endereco.logradouro).toBe(
+      dioceseData.endereco.logradouro,
+    );
+    expect(response.body.data.endereco.cidade.nome).toBe(
+      dioceseData.endereco.cidade,
+    );
+    expect(response.body.data.endereco.cidade.estado.sigla).toBe(
+      dioceseData.endereco.UF,
+    );
+  });
 
-  //   await request(app.getHttpServer())
-  //     .patch(`/${principal}/2`)
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .set('Content-Type', 'application/json')
-  //     .send(dioceseData)
-  //     .expect(404)
-  //     .expect((res) => {
-  //       expect(res.body.message).toBe(
-  //         'Endereço id 9874 não encontrada para essa diocese',
-  //       );
-  //       expect(res.body.error).toBe('Not Found');
-  //       expect(res.body.statusCode).toBe(404);
-  //     });
-  // });
+  it(`/${principal} (PATCH) - 404 | não deve atualizar uma paroquia com id endereco que nao pertence a ela mesma`, async () => {
+    const dioceseData = {
+      descricao: faker.company.name(),
+      diocese: { id: 2 },
+      endereco: {
+        id: 9874,
+        cep: faker.location.zipCode('########'),
+        logradouro: faker.location.streetAddress(),
+        numero: '1226',
+        bairro: faker.location.secondaryAddress(),
+        cidade: faker.location.city(),
+        UF: 'SP',
+      },
+    };
+
+    await request(app.getHttpServer())
+      .patch(`/${principal}/2`)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send(dioceseData)
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(
+          'Endereço id 9874 não encontrada para essa paroquia.',
+        );
+        expect(res.body.error).toBe('Not Found');
+        expect(res.body.statusCode).toBe(404);
+      });
+  });
 });

--- a/test/paroquia.e2e-spec.ts
+++ b/test/paroquia.e2e-spec.ts
@@ -1,0 +1,319 @@
+import { INestApplication } from '@nestjs/common';
+import { setupTestModule } from './test-setup';
+import request from 'supertest';
+
+describe('ParoquiaController (e2e)', () => {
+  let app: INestApplication;
+  const principal = 'paroquia';
+  let token = '';
+
+  beforeAll(async () => {
+    app = await setupTestModule();
+
+    const response = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'admin@admin.com', password: 'admin' });
+
+    token = response.body.data.access_token;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it(`/${principal} (GET) - 401 | nao pode ver paroquia se nao tiver autenticado`, () => {
+    return request(app.getHttpServer())
+      .get(`/${principal}`)
+      .expect(401)
+      .expect((res) => {
+        expect(res.body.message).toBe('Invalid or missing token');
+        expect(res.body.error).toBe('Unauthorized');
+        expect(res.body.statusCode).toBe(401);
+      });
+  });
+
+  it(`/${principal} (GET) - 403 | nao pode ver paroquia se nao tiver permissao`, async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'ronaldinho@admin.com', password: 'admin' });
+
+    const tokenNaoPermitido = response.body.data.access_token;
+
+    return request(app.getHttpServer())
+      .get(`/${principal}`)
+      .set('Authorization', `Bearer ${tokenNaoPermitido}`)
+      .expect(403)
+      .expect((res) => {
+        expect(res.body.message).toBe(
+          'Você não tem permissão para listar paroquias',
+        );
+        expect(res.body.error).toBe('Forbidden');
+        expect(res.body.statusCode).toBe(403);
+      });
+  });
+
+  it(`/${principal} (GET) - 403 | nao pode ver paroquia by id se nao tiver permissao`, async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'ronaldinho@admin.com', password: 'admin' });
+
+    const tokenNaoPermitido = response.body.data.access_token;
+
+    return request(app.getHttpServer())
+      .get(`/${principal}/1`)
+      .set('Authorization', `Bearer ${tokenNaoPermitido}`)
+      .expect(403)
+      .expect((res) => {
+        expect(res.body.message).toBe(
+          'Você não tem permissão para listar paroquias',
+        );
+        expect(res.body.error).toBe('Forbidden');
+        expect(res.body.statusCode).toBe(403);
+      });
+  });
+
+  it(`/${principal} (GET) - 404 | deve retornar paroquia nao encontrada by id`, () => {
+    return request(app.getHttpServer())
+      .get(`/${principal}/4324`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404)
+      .expect((res) => {
+        expect(res.body.message).toBe(
+          `O registro de 'Paroquia' não foi encontrado.`,
+        );
+        expect(res.body.statusCode).toBe(404);
+      });
+  });
+
+  // it(`/${principal} (GET) - 200 | deve retornar paroquias com campos obrigatórios preenchidos`, () => {
+  //   return request(app.getHttpServer())
+  //     .get(`/${principal}`)
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .expect(200)
+  //     .expect((res) => {
+  //       const paroquia = res.body.data[0]; // Pega a primeira paroquia da lista
+
+  //       // Verifica se a estrutura básica está correta
+  //       expect(res.body).toHaveProperty('server');
+  //       expect(res.body).toHaveProperty('total');
+  //       expect(res.body).toHaveProperty('page');
+  //       expect(res.body).toHaveProperty('limit');
+  //       expect(res.body.data).toBeInstanceOf(Array);
+
+  //       // Valida campos obrigatórios da paroquia
+  //       expect(paroquia).toHaveProperty('id');
+  //       expect(paroquia).toHaveProperty('descricao');
+
+  //       // Valida se 'tipoDiocese' está preenchido corretamente
+  //       expect(paroquia.tipoDiocese).toBeDefined();
+  //       expect(paroquia.tipoDiocese).toHaveProperty('id');
+  //       expect(paroquia.tipoDiocese).toHaveProperty('descricao');
+
+  //       // Valida se 'endereco' está preenchido corretamente
+  //       expect(paroquia.endereco).toBeDefined();
+  //       expect(paroquia.endereco).toHaveProperty('id');
+  //       expect(paroquia.endereco).toHaveProperty('cep');
+  //       expect(paroquia.endereco).toHaveProperty('logradouro');
+  //       expect(paroquia.endereco).toHaveProperty('cidade');
+  //       expect(paroquia.endereco.cidade).toHaveProperty('estado');
+  //       expect(paroquia.endereco.cidade.estado).toHaveProperty('pais');
+  //       expect(paroquia.endereco).toHaveProperty('bairro');
+  //       expect(paroquia.endereco).toHaveProperty('numero');
+  //       expect(paroquia.endereco).toHaveProperty('observacao');
+  //     });
+  // });
+
+  // it(`/${principal} (POST) - 201 | deve criar uma diocese com campos válidos`, async () => {
+  //   const dioceseData = {
+  //     descricao: 'Jenkins, Mosciski and Marvin',
+  //     tipoDiocese: { id: 2, descricao: 'Diocese' },
+  //     endereco: {
+  //       cep: faker.location.zipCode('########'),
+  //       logradouro: faker.location.streetAddress(),
+  //       numero: '32',
+  //       bairro: faker.location.secondaryAddress(),
+  //       UF: 'SP',
+  //       cidade: 'Nuporanga',
+  //     },
+  //   };
+
+  //   const response = await request(app.getHttpServer())
+  //     .post(`/${principal}`)
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .set('Content-Type', 'application/json')
+  //     .send(dioceseData)
+  //     .expect(201);
+
+  //   expect(response.body.data).toHaveProperty('id');
+  //   expect(response.body.data.descricao).toBe(dioceseData.descricao);
+  //   expect(response.body.data.tipoDiocese.id).toBe(dioceseData.tipoDiocese.id);
+  //   expect(response.body.data.endereco.cep).toBe(dioceseData.endereco.cep);
+  //   expect(response.body.data.endereco.bairro).toBe(
+  //     dioceseData.endereco.bairro,
+  //   );
+  //   expect(response.body.data.endereco.logradouro).toBe(
+  //     dioceseData.endereco.logradouro,
+  //   );
+  //   expect(response.body.data.endereco.numero).toBe(
+  //     dioceseData.endereco.numero,
+  //   );
+  //   expect(response.body.data.endereco.cidade.nome).toBe(
+  //     dioceseData.endereco.cidade,
+  //   );
+  //   expect(response.body.data.endereco.cidade.estado.sigla).toBe(
+  //     dioceseData.endereco.UF,
+  //   );
+  //   expect(response.body.data.endereco.cidade.estado.pais.nome).toBe('Brasil');
+  //   expect(response.body.data.endereco.observacao).toBeDefined();
+  // });
+
+  // it(`/${principal} (POST) - 404 | nao deve criar uma diocese tipo diocese invalida`, async () => {
+  //   const dioceseData = {
+  //     descricao: 'Jenkins, Mosciski and Marvin',
+  //     tipoDiocese: { id: 489, descricao: 'Diocese Mentira' },
+  //     endereco: {
+  //       cep: faker.location.zipCode('########'),
+  //       logradouro: faker.location.streetAddress(),
+  //       numero: '32',
+  //       bairro: faker.location.secondaryAddress(),
+  //       UF: 'SP',
+  //       cidade: 'Nuporanga',
+  //     },
+  //   };
+
+  //   await request(app.getHttpServer())
+  //     .post(`/${principal}`)
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .set('Content-Type', 'application/json')
+  //     .send(dioceseData)
+  //     .expect(404)
+  //     .expect((res) => {
+  //       expect(res.body.message).toBe(`Tipo de diocese não encontrada`);
+  //       expect(res.body.error).toBe('Not Found');
+  //       expect(res.body.statusCode).toBe(404);
+  //     });
+  // });
+
+  // it(`/${principal} (POST) - 400 | nao deve criar uma diocese tipo diocese null`, async () => {
+  //   const dioceseData = {
+  //     descricao: faker.company.name(),
+  //     endereco: {
+  //       cep: faker.location.zipCode('########'),
+  //       logradouro: faker.location.streetAddress(),
+  //       numero: '32',
+  //       bairro: faker.location.secondaryAddress(),
+  //       UF: 'SP',
+  //       cidade: 'Nuporanga',
+  //     },
+  //   };
+
+  //   await request(app.getHttpServer())
+  //     .post(`/${principal}`)
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .set('Content-Type', 'application/json')
+  //     .send(dioceseData)
+  //     .expect(400)
+  //     .expect((res) => {
+  //       expect(res.body.message[0]).toBe(`tipoDiocese must be an object`);
+  //       expect(res.body.error).toBe('Bad Request');
+  //       expect(res.body.statusCode).toBe(400);
+  //     });
+  // });
+
+  // it(`/${principal} (POST) - 401 | deve falhar sem autenticação`, async () => {
+  //   await request(app.getHttpServer())
+  //     .post(`/${principal}`)
+  //     .send({ descricao: 'Diocese sem token' })
+  //     .expect(401)
+  //     .expect((res) => {
+  //       expect(res.body.message).toBe('Invalid or missing token');
+  //       expect(res.body.error).toBe('Unauthorized');
+  //       expect(res.body.statusCode).toBe(401);
+  //     });
+  // });
+
+  // it(`/${principal}/1 (PATCH) - 401 | deve falhar sem autenticação by id`, async () => {
+  //   await request(app.getHttpServer())
+  //     .patch(`/${principal}/1`)
+  //     .send({ descricao: 'Diocese sem token' })
+  //     .expect(401)
+  //     .expect((res) => {
+  //       expect(res.body.message).toBe('Invalid or missing token');
+  //       expect(res.body.error).toBe('Unauthorized');
+  //       expect(res.body.statusCode).toBe(401);
+  //     });
+  // });
+
+  // it(`/${principal} (PATCH) - 200 | deve atualizar uma diocese com campos válidos`, async () => {
+  //   const dioceseData = {
+  //     descricao: faker.company.name(),
+  //     tipoDiocese: { id: 2, descricao: 'Diocese' },
+  //     endereco: {
+  //       id: 2,
+  //       cep: faker.location.zipCode('########'),
+  //       logradouro: faker.location.streetAddress(),
+  //       numero: '1226',
+  //       bairro: faker.location.secondaryAddress(),
+  //       cidade: faker.location.city(),
+  //       UF: 'SP',
+  //     },
+  //   };
+
+  //   const response = await request(app.getHttpServer())
+  //     .patch(`/${principal}/2`)
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .set('Content-Type', 'application/json')
+  //     .send(dioceseData)
+  //     .expect(200);
+
+  //   expect(response.body.data).toHaveProperty('id');
+  //   expect(response.body.data.descricao).toBe(dioceseData.descricao);
+  //   expect(response.body.data.tipoDiocese.id).toBe(dioceseData.tipoDiocese.id);
+  //   expect(response.body.data.endereco.cep).toBe(dioceseData.endereco.cep);
+  //   expect(response.body.data.endereco.bairro).toBe(
+  //     dioceseData.endereco.bairro,
+  //   );
+  //   expect(response.body.data.endereco.numero).toBe(
+  //     dioceseData.endereco.numero,
+  //   );
+  //   expect(response.body.data.endereco.logradouro).toBe(
+  //     dioceseData.endereco.logradouro,
+  //   );
+  //   expect(response.body.data.endereco.cidade.nome).toBe(
+  //     dioceseData.endereco.cidade,
+  //   );
+  //   expect(response.body.data.endereco.cidade.estado.sigla).toBe(
+  //     dioceseData.endereco.UF,
+  //   );
+  // });
+
+  // it(`/${principal} (PATCH) - 404 | não deve atualizar uma diocese com id endereco de outra diocese`, async () => {
+  //   const dioceseData = {
+  //     descricao: faker.company.name(),
+  //     tipoDiocese: { id: 2, descricao: 'Diocese' },
+  //     endereco: {
+  //       id: 9874,
+  //       cep: faker.location.zipCode('########'),
+  //       logradouro: faker.location.streetAddress(),
+  //       numero: '1226',
+  //       bairro: faker.location.secondaryAddress(),
+  //       cidade: faker.location.city(),
+  //       UF: 'SP',
+  //     },
+  //   };
+
+  //   await request(app.getHttpServer())
+  //     .patch(`/${principal}/2`)
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .set('Content-Type', 'application/json')
+  //     .send(dioceseData)
+  //     .expect(404)
+  //     .expect((res) => {
+  //       expect(res.body.message).toBe(
+  //         'Endereço id 9874 não encontrada para essa diocese',
+  //       );
+  //       expect(res.body.error).toBe('Not Found');
+  //       expect(res.body.statusCode).toBe(404);
+  //     });
+  // });
+});

--- a/test/paroquia.e2e-spec.ts
+++ b/test/paroquia.e2e-spec.ts
@@ -187,7 +187,7 @@ describe('ParoquiaController (e2e)', () => {
   });
 
   it(`/${principal} (POST) - 201 | deve criar uma paroquia com campos válidos`, async () => {
-    const dioceseData = {
+    const paroquiaData = {
       descricao: faker.company.name(),
       diocese: { id: 1 },
       endereco: {
@@ -196,7 +196,7 @@ describe('ParoquiaController (e2e)', () => {
         numero: '32',
         bairro: faker.location.secondaryAddress(),
         UF: 'SP',
-        cidade: 'Nuporanga',
+        cidade: faker.location.city(),
       },
     };
 
@@ -204,27 +204,27 @@ describe('ParoquiaController (e2e)', () => {
       .post(`/${principal}`)
       .set('Authorization', `Bearer ${token}`)
       .set('Content-Type', 'application/json')
-      .send(dioceseData)
+      .send(paroquiaData)
       .expect(201);
 
     expect(response.body.data).toHaveProperty('id');
-    expect(response.body.data.descricao).toBe(dioceseData.descricao);
-    expect(response.body.data.diocese.id).toBe(dioceseData.diocese.id);
-    expect(response.body.data.endereco.cep).toBe(dioceseData.endereco.cep);
+    expect(response.body.data.descricao).toBe(paroquiaData.descricao);
+    expect(response.body.data.diocese.id).toBe(paroquiaData.diocese.id);
+    expect(response.body.data.endereco.cep).toBe(paroquiaData.endereco.cep);
     expect(response.body.data.endereco.bairro).toBe(
-      dioceseData.endereco.bairro,
+      paroquiaData.endereco.bairro,
     );
     expect(response.body.data.endereco.logradouro).toBe(
-      dioceseData.endereco.logradouro,
+      paroquiaData.endereco.logradouro,
     );
     expect(response.body.data.endereco.numero).toBe(
-      dioceseData.endereco.numero,
+      paroquiaData.endereco.numero,
     );
     expect(response.body.data.endereco.cidade.nome).toBe(
-      dioceseData.endereco.cidade,
+      paroquiaData.endereco.cidade,
     );
     expect(response.body.data.endereco.cidade.estado.sigla).toBe(
-      dioceseData.endereco.UF,
+      paroquiaData.endereco.UF,
     );
     expect(response.body.data.endereco.cidade.estado.pais.nome).toBe('Brasil');
     expect(response.body.data.endereco.observacao).toBeDefined();

--- a/test/paroquia.e2e-spec.ts
+++ b/test/paroquia.e2e-spec.ts
@@ -85,43 +85,56 @@ describe('ParoquiaController (e2e)', () => {
       });
   });
 
-  // it(`/${principal} (GET) - 200 | deve retornar paroquias com campos obrigatórios preenchidos`, () => {
-  //   return request(app.getHttpServer())
-  //     .get(`/${principal}`)
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .expect(200)
-  //     .expect((res) => {
-  //       const paroquia = res.body.data[0]; // Pega a primeira paroquia da lista
+  it(`/${principal} (GET) - 200 | deve retornar paroquias com campos obrigatórios preenchidos`, () => {
+    return request(app.getHttpServer())
+      .get(`/${principal}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        const paroquia = res.body.data[0];
 
-  //       // Verifica se a estrutura básica está correta
-  //       expect(res.body).toHaveProperty('server');
-  //       expect(res.body).toHaveProperty('total');
-  //       expect(res.body).toHaveProperty('page');
-  //       expect(res.body).toHaveProperty('limit');
-  //       expect(res.body.data).toBeInstanceOf(Array);
+        // Verifica se a estrutura básica está correta
+        expect(res.body).toHaveProperty('server');
+        expect(res.body).toHaveProperty('total');
+        expect(res.body).toHaveProperty('page');
+        expect(res.body).toHaveProperty('limit');
+        expect(res.body.data).toBeInstanceOf(Array);
 
-  //       // Valida campos obrigatórios da paroquia
-  //       expect(paroquia).toHaveProperty('id');
-  //       expect(paroquia).toHaveProperty('descricao');
+        // Valida campos obrigatórios da paroquia
+        expect(paroquia).toHaveProperty('id');
+        expect(paroquia).toHaveProperty('descricao');
 
-  //       // Valida se 'tipoDiocese' está preenchido corretamente
-  //       expect(paroquia.tipoDiocese).toBeDefined();
-  //       expect(paroquia.tipoDiocese).toHaveProperty('id');
-  //       expect(paroquia.tipoDiocese).toHaveProperty('descricao');
+        // Valida se 'endereco' está preenchido corretamente
+        expect(paroquia.endereco).toBeDefined();
+        expect(paroquia.endereco).toHaveProperty('id');
+        expect(paroquia.endereco).toHaveProperty('cep');
+        expect(paroquia.endereco).toHaveProperty('logradouro');
+        expect(paroquia.endereco).toHaveProperty('cidade');
+        expect(paroquia.endereco.cidade).toHaveProperty('estado');
+        expect(paroquia.endereco.cidade.estado).toHaveProperty('pais');
+        expect(paroquia.endereco).toHaveProperty('bairro');
+        expect(paroquia.endereco).toHaveProperty('numero');
+        expect(paroquia.endereco).toHaveProperty('observacao');
 
-  //       // Valida se 'endereco' está preenchido corretamente
-  //       expect(paroquia.endereco).toBeDefined();
-  //       expect(paroquia.endereco).toHaveProperty('id');
-  //       expect(paroquia.endereco).toHaveProperty('cep');
-  //       expect(paroquia.endereco).toHaveProperty('logradouro');
-  //       expect(paroquia.endereco).toHaveProperty('cidade');
-  //       expect(paroquia.endereco.cidade).toHaveProperty('estado');
-  //       expect(paroquia.endereco.cidade.estado).toHaveProperty('pais');
-  //       expect(paroquia.endereco).toHaveProperty('bairro');
-  //       expect(paroquia.endereco).toHaveProperty('numero');
-  //       expect(paroquia.endereco).toHaveProperty('observacao');
-  //     });
-  // });
+        // Valida se diocese esta no response
+        expect(paroquia.diocese).toHaveProperty('id');
+        expect(paroquia.diocese).toHaveProperty('descricao');
+        expect(paroquia.diocese.endereco).toBeDefined();
+        expect(paroquia.diocese.endereco).toHaveProperty('id');
+        expect(paroquia.diocese.endereco).toHaveProperty('cep');
+        expect(paroquia.diocese.endereco).toHaveProperty('logradouro');
+        expect(paroquia.diocese.endereco).toHaveProperty('cidade');
+        expect(paroquia.diocese.endereco.cidade).toHaveProperty('estado');
+        expect(paroquia.diocese.endereco.cidade.estado).toHaveProperty('pais');
+        expect(paroquia.diocese.endereco).toHaveProperty('bairro');
+        expect(paroquia.diocese.endereco).toHaveProperty('numero');
+        expect(paroquia.diocese.endereco).toHaveProperty('observacao');
+        // Valida se 'tipoDiocese' está preenchido corretamente
+        expect(paroquia.diocese.tipoDiocese).toBeDefined();
+        expect(paroquia.diocese.tipoDiocese).toHaveProperty('id');
+        expect(paroquia.diocese.tipoDiocese).toHaveProperty('descricao');
+      });
+  });
 
   // it(`/${principal} (POST) - 201 | deve criar uma diocese com campos válidos`, async () => {
   //   const dioceseData = {


### PR DESCRIPTION
#50

## Resumo por Sourcery

Implementa a funcionalidade de Paróquia com serviço abrangente, validação de dados e controle de acesso

Novas Funcionalidades:
- Adiciona serviço completo de Paróquia com operações de criar, ler, atualizar e deletar
- Implementa validação de dados para a criação de Paróquia
- Adiciona controle de acesso baseado em permissões para entidades de Paróquia

Melhorias:
- Cria queries de seleção reutilizáveis para Paróquia, Diocese e Endereco
- Melhora o tratamento de erros e o registro em log nos métodos de serviço
- Adiciona serialização para objetos de resposta de Paróquia

Testes:
- Atualiza testes unitários para ParoquiaService e ParoquiaController
- Adiciona configuração de teste e2e para Paróquia

Tarefas:
- Atualiza o script de seed para incluir dados iniciais de Paróquia
- Modifica o serviço de habilidade CASL para incluir permissões de Paróquia

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement Paroquia (Parish) functionality with comprehensive service, data validation, and access control

New Features:
- Add complete Paroquia service with create, read, update, and delete operations
- Implement data validation for Paroquia creation
- Add permission-based access control for Paroquia entities

Enhancements:
- Create reusable select queries for Paroquia, Diocese, and Endereco
- Improve error handling and logging in service methods
- Add serialization for Paroquia response objects

Tests:
- Update unit tests for ParoquiaService and ParoquiaController
- Add e2e test setup for Paroquia

Chores:
- Update seed script to include initial Paroquia data
- Modify CASL ability service to include Paroquia permissions

</details>