### PR TITLE
:sparkles: dados do usuario

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,7 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Acionar deploy automático
+        run: |
+          curl -X GET "${{ secrets.EASY_PANEL_DEPLOY_AUTOMATIC }}"

--- a/src/commons/interceptors/pagination.interceptors.ts
+++ b/src/commons/interceptors/pagination.interceptors.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
-import { map, Observable } from "rxjs";
-import { LIMIT_DEFAULT, PAGE_DEFAULT } from "../constants/constants";
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { map, Observable } from 'rxjs';
+import { LIMIT_DEFAULT, PAGE_DEFAULT } from '../constants/constants';
 
 interface Pagination {
   server: string;
@@ -13,37 +18,37 @@ interface Pagination {
 
 @Injectable()
 export class PaginationInterceptor implements NestInterceptor {
-  intercept(context: ExecutionContext, next: CallHandler<any>): Observable<any> | Promise<Observable<any>> {
-    return next
-      .handle()
-      .pipe(
-        map((data) => {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Observable<any> | Promise<Observable<any>> {
+    return next.handle().pipe(
+      map((data) => {
+        const req = context.switchToHttp().getRequest();
+        const host = `${req.hostname}${req.url}`;
 
-          const req = context.switchToHttp().getRequest()
-          const host = `${req.hostname}${req.url}`
+        const server = host;
+        const isArray = Array.isArray(data);
+        const total = isArray ? data.length : 1;
+        const page = parseInt(req.query.page) || PAGE_DEFAULT;
+        let limit = LIMIT_DEFAULT;
 
-          const server = host;
-          const total = data.length;
-          const page = parseInt(req.query.page) || PAGE_DEFAULT;
-          let limit = LIMIT_DEFAULT;
+        if (req.query.limit) {
+          limit = parseInt(req.query.limit);
+        }
 
-          if (req.query.limit) {
-            limit = parseInt(req.query.limit)
-          }
-          
-          if (total < limit) {
-            limit = total;
-          }
+        if (total < limit) {
+          limit = total;
+        }
 
-          return {
-            server,
-            total,
-            page,
-            limit,
-            data,
-          } as Pagination;
-        }),
-      );
+        return {
+          server,
+          total,
+          page,
+          limit,
+          data,
+        } as Pagination;
+      }),
+    );
   }
-
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,1 +1,0 @@
-export class User {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -7,7 +7,9 @@ import {
   Param,
   Delete,
   UseGuards,
+  Req,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -27,6 +29,11 @@ export class UsersController {
   @Get()
   findAll() {
     return this.usersService.findAll();
+  }
+
+  @Get('me')
+  getMe(@Req() req: Request) {
+    return req.user;
   }
 
   @Get(':id')

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -2,6 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
 import { PrismaService } from 'src/prisma.service';
 import { CaslAbilityService } from 'src/casl/casl-ability/casl-ability.service';
+import { ForbiddenException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { ROLE_ENUM } from 'src/commons/enums/enums';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -32,4 +35,102 @@ describe('UsersService', () => {
     expect(prismaService).toBeDefined();
     expect(abilityService).toBeDefined();
   });
+
+  describe('UsersService', () => {
+    let service: UsersService;
+    let prismaService: any;
+    let abilityService: any;
+
+    beforeEach(async () => {
+      prismaService = {
+        user: {
+          create: jest.fn(),
+          findMany: jest.fn(),
+          findUnique: jest.fn(),
+          update: jest.fn(),
+          delete: jest.fn(),
+        },
+      };
+      abilityService = {
+        ability: {
+          can: jest.fn(),
+        },
+      };
+      service = new UsersService(prismaService, abilityService);
+    });
+
+    describe('create', () => {
+      it('should hash password and create user with default role', async () => {
+        const dto = { username: 'test', password: 'pass123' };
+        prismaService.user.create.mockResolvedValue({ id: '1', ...dto, role: ROLE_ENUM.NAO_IDENTIFICADO });
+        const result = await service.create(dto as any);
+        expect(bcrypt.hash).toBeDefined();
+        expect(prismaService.user.create).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            username: 'test',
+            role: ROLE_ENUM.NAO_IDENTIFICADO,
+          }),
+        });
+        expect(result.role).toBe(ROLE_ENUM.NAO_IDENTIFICADO);
+      });
+    });
+
+    describe('findAll', () => {
+      it('should return users if ability allows', async () => {
+        abilityService.ability.can.mockReturnValue(true);
+        prismaService.user.findMany.mockResolvedValue([{ id: '1' }]);
+        const result = await service.findAll();
+        expect(prismaService.user.findMany).toHaveBeenCalled();
+        expect(result).toEqual([{ id: '1' }]);
+      });
+
+      it('should throw ForbiddenException if ability denies', () => {
+        abilityService.ability.can.mockReturnValue(false);
+        expect(() => service.findAll()).toThrow(ForbiddenException);
+      });
+    });
+
+    describe('findOne', () => {
+      it('should return user by id', async () => {
+        prismaService.user.findUnique.mockResolvedValue({ id: '1' });
+        const result = await service.findOne('1');
+        expect(prismaService.user.findUnique).toHaveBeenCalledWith({ where: { id: '1' } });
+        expect(result).toEqual({ id: '1' });
+      });
+    });
+
+    describe('update', () => {
+      it('should hash password if provided and update user', async () => {
+        const dto = { password: 'newpass', username: 'updated' };
+        prismaService.user.update.mockResolvedValue({ id: '1', ...dto });
+        const result = await service.update('1', { ...dto } as any);
+        expect(prismaService.user.update).toHaveBeenCalledWith({
+          where: { id: '1' },
+          data: expect.objectContaining({ username: 'updated' }),
+        });
+        expect(result.id).toBe('1');
+      });
+
+      it('should update user without hashing if password not provided', async () => {
+        const dto = { username: 'updated' };
+        prismaService.user.update.mockResolvedValue({ id: '1', ...dto });
+        const result = await service.update('1', { ...dto } as any);
+        expect(prismaService.user.update).toHaveBeenCalledWith({
+          where: { id: '1' },
+          data: expect.objectContaining({ username: 'updated' }),
+        });
+        expect(result.id).toBe('1');
+      });
+    });
+
+    describe('remove', () => {
+      it('should delete user by id', async () => {
+        prismaService.user.delete.mockResolvedValue({ id: '1' });
+        const result = await service.remove('1');
+        expect(prismaService.user.delete).toHaveBeenCalledWith({ where: { id: '1' } });
+        expect(result).toEqual({ id: '1' });
+      });
+    });
+  });
+  
 });

--- a/test/users/user.e2e-spec.ts
+++ b/test/users/user.e2e-spec.ts
@@ -53,7 +53,7 @@ describe('UserController (e2e)', () => {
     expect(response.body).toMatchObject({
       server: '127.0.0.1/users',
       page: 1,
-      limit: 50,
+      limit: 1,
       data: {
         email,
         name,


### PR DESCRIPTION
agora temos dados do usuario para o front

## Resumo por Sourcery

Fornecer endpoints de dados do usuário e melhorar a confiabilidade dos testes e a automação de implantação

Novos Recursos:
- Expor o endpoint GET /users/me para buscar dados do usuário autenticado

Melhorias:
- Refatorar a formatação do interceptor de paginação e remover entidade de usuário não utilizada

CI:
- Adicionar etapa de implantação automática no fluxo de trabalho de lançamento do GitHub Actions

Testes:
- Adicionar testes unitários abrangentes para métodos do UsersService
- Atualizar teste de usuário e2e para refletir o novo limite de paginação

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide user data endpoints and improve test reliability and deployment automation

New Features:
- Expose GET /users/me endpoint to fetch authenticated user data

Enhancements:
- Refactor pagination interceptor formatting and remove unused user entity

CI:
- Add automatic deploy step in GitHub Actions release workflow

Tests:
- Add comprehensive unit tests for UsersService methods
- Update e2e user test to reflect new pagination limit

</details>