### PR TITLE
:sparkles: cadastro de usuarios ok

### DIFF
--- a/prisma/migrations/20250809180853_alter_table_user_add_cpf_e_pessoa_id/migration.sql
+++ b/prisma/migrations/20250809180853_alter_table_user_add_cpf_e_pessoa_id/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "ambrosio"."user" ADD COLUMN     "cpf" VARCHAR(11),
+ADD COLUMN     "pessoaId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "ambrosio"."user" ADD CONSTRAINT "user_pessoaId_fkey" FOREIGN KEY ("pessoaId") REFERENCES "ambrosio"."pessoa"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,7 @@ model pessoa {
   carismasServico      pessoaCarismaServico[]
   carismasVinculado    pessoaCarismaVinculado[]
   carismasPrimitivo    pessoaCarismaPrimitivo[]
+  user                 user[]
 
   @@schema("ambrosio")
 }
@@ -317,6 +318,9 @@ model user {
   password         String
   role             roles    @default(NAO_IDENTIFICADO)
   whatsapp         String?  @db.VarChar(20)
+  cpf              String?  @db.VarChar(11)
+  pessoaId         Int?
+  pessoa           pessoa?  @relation(fields: [pessoaId], references: [id])
   verifiedWhatsapp Boolean  @default(false)
   active           Boolean  @default(false)
   createdAt        DateTime @default(now())

--- a/src/diocese/diocese.service.ts
+++ b/src/diocese/diocese.service.ts
@@ -30,6 +30,12 @@ export class DioceseService {
   ) {}
 
   async create(createDioceseDto: CreateDioceseDto): Promise<Diocese> {
+    const { ability } = this.abilityService;
+    if (!ability.can('create', 'diocese')) {
+      throw new ForbiddenException(
+        'Você não tem permissão para criar dioceses',
+      );
+    }
     await this.tipoDioceseService.findOne(createDioceseDto.tipoDiocese.id);
 
     try {
@@ -63,7 +69,7 @@ export class DioceseService {
   }
 
   async findAll(): Promise<Diocese[]> {
-    const where = this.asPermissions();
+    const where = this.asPermissionsRead();
     const results = await this.prisma.diocese.findMany({
       where,
       select: DIOCESE_SELECT,
@@ -73,7 +79,7 @@ export class DioceseService {
   }
 
   async findOne(id: number): Promise<Diocese> {
-    const wherePermissions = this.asPermissions();
+    const wherePermissions = this.asPermissionsRead();
     const diocese = await this.prisma.diocese.findFirstOrThrow({
       where: {
         AND: [{ id }, wherePermissions],
@@ -143,7 +149,7 @@ export class DioceseService {
     return `This action removes a #${id} diocese`;
   }
 
-  private asPermissions() {
+  private asPermissionsRead() {
     const { ability } = this.abilityService;
     if (!ability.can('read', 'diocese')) {
       throw new ForbiddenException(

--- a/src/paroquia/paroquia.service.ts
+++ b/src/paroquia/paroquia.service.ts
@@ -30,6 +30,12 @@ export class ParoquiaService {
   ) {}
 
   async create(createParoquiaDto: CreateParoquiaDto) {
+    const { ability } = this.abilityService;
+    if (!ability.can('create', 'paroquia')) {
+      throw new ForbiddenException(
+        'Você não tem permissão para criar paróquias',
+      );
+    }
     await this.dioceseService.findOne(createParoquiaDto.diocese.id);
 
     try {

--- a/src/pessoa/pessoa.module.ts
+++ b/src/pessoa/pessoa.module.ts
@@ -12,6 +12,7 @@ import { TipoCarismaServicoModule } from 'src/configuracoes/carismas/tipo-carism
 @Module({
   controllers: [PessoaController],
   providers: [PessoaService],
+  exports: [PessoaService],
   imports: [
     EscolaridadeModule,
     EstadoCivilModule,

--- a/src/pessoa/pessoa.service.ts
+++ b/src/pessoa/pessoa.service.ts
@@ -275,6 +275,12 @@ export class PessoaService {
     );
   }
 
+  async findOneByCpf(cpf: string) {
+    return await this.prisma.pessoa.findFirst({
+      where: { cpf },
+    });
+  }
+
   async findOne(id: number) {
     const result: pessoa = await this.prisma.pessoa.findUniqueOrThrow({
       where: { id },
@@ -407,16 +413,14 @@ export class PessoaService {
     }
   }
 
-  private async analisarCPF(cpf: string) {
+  async analisarCPF(cpf: string) {
     // TODO: colocar validacao de CPF aqui
 
     if (cpf === undefined || cpf === '') {
       return;
     }
 
-    const pessoa = await this.prisma.pessoa.findFirst({
-      where: { cpf },
-    });
+    const pessoa = await this.findOneByCpf(cpf);
     if (pessoa) {
       throw new ConflictException(
         `O CPF ja registrado para ${pessoa.nome} de id: ${pessoa.id}`,

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,4 +1,11 @@
-import { IsEmail, IsMobilePhone, IsString, MaxLength } from 'class-validator';
+import {
+  IsEmail,
+  IsMobilePhone,
+  IsNumberString,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreateUserDto {
   @IsString()
@@ -13,4 +20,9 @@ export class CreateUserDto {
   @IsMobilePhone('pt-BR')
   @MaxLength(13)
   whatsapp: string;
+
+  @MaxLength(11)
+  @MinLength(11)
+  @IsNumberString()
+  cpf: string;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -4,20 +4,41 @@ import { UsersService } from './users.service';
 import { PrismaService } from 'src/prisma.service';
 import { JwtService } from '@nestjs/jwt';
 import { CaslAbilityService } from 'src/casl/casl-ability/casl-ability.service';
+import { PessoaService } from 'src/pessoa/pessoa.service';
+import { EstadoCivilService } from 'src/configuracoes/estado-civil/estado-civil.service';
+import { TipoCarismaPrimitivoService } from 'src/configuracoes/carismas/tipo-carisma-primitivo/tipo-carisma-primitivo.service';
+import { TipoCarismaVinculadoService } from 'src/configuracoes/carismas/tipo-carisma-vinculado/tipo-carisma-vinculado.service';
+import { TipoCarismaServicoService } from 'src/configuracoes/carismas/tipo-carisma-servico/tipo-carisma-servico.service';
+import { EscolaridadeService } from 'src/configuracoes/escolaridade/escolaridade.service';
+import { SituacaoReligiosaService } from 'src/configuracoes/situacao-religiosa/situacao-religiosa.service';
 
 describe('UsersController', () => {
   let controller: UsersController;
   let prismaService: PrismaService;
   let jwtservice: JwtService;
   let abilityService: CaslAbilityService;
+  let pessoaService: PessoaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
-      providers: [UsersService, PrismaService, JwtService, CaslAbilityService],
+      providers: [
+        UsersService,
+        PrismaService,
+        JwtService,
+        CaslAbilityService,
+        PessoaService,
+        EstadoCivilService,
+        TipoCarismaPrimitivoService,
+        TipoCarismaVinculadoService,
+        TipoCarismaServicoService,
+        EscolaridadeService,
+        SituacaoReligiosaService,
+      ],
     }).compile();
 
     controller = module.get<UsersController>(UsersController);
+    pessoaService = module.get<PessoaService>(PessoaService);
     prismaService = module.get<PrismaService>(PrismaService);
     jwtservice = module.get<JwtService>(JwtService);
     abilityService =
@@ -29,5 +50,6 @@ describe('UsersController', () => {
     expect(prismaService).toBeDefined();
     expect(jwtservice).toBeDefined();
     expect(abilityService).toBeDefined();
+    expect(pessoaService).toBeDefined();
   });
 });

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { PessoaModule } from 'src/pessoa/pessoa.module';
 
 @Module({
   controllers: [UsersController],
   providers: [UsersService],
+  imports: [PessoaModule],
 })
 export class UsersModule {}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,20 +1,26 @@
+import { SituacaoReligiosaService } from 'src/configuracoes/situacao-religiosa/situacao-religiosa.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
 import { PrismaService } from 'src/prisma.service';
 import { CaslAbilityService } from 'src/casl/casl-ability/casl-ability.service';
-import { ForbiddenException } from '@nestjs/common';
-import * as bcrypt from 'bcrypt';
-import { ROLE_ENUM } from 'src/commons/enums/enums';
+import { PessoaService } from 'src/pessoa/pessoa.service';
+import { EstadoCivilService } from 'src/configuracoes/estado-civil/estado-civil.service';
+import { EscolaridadeService } from 'src/configuracoes/escolaridade/escolaridade.service';
+import { TipoCarismaPrimitivoService } from 'src/configuracoes/carismas/tipo-carisma-primitivo/tipo-carisma-primitivo.service';
+import { TipoCarismaVinculadoService } from 'src/configuracoes/carismas/tipo-carisma-vinculado/tipo-carisma-vinculado.service';
+import { TipoCarismaServicoService } from 'src/configuracoes/carismas/tipo-carisma-servico/tipo-carisma-servico.service';
 
 describe('UsersService', () => {
   let service: UsersService;
   let prismaService: PrismaService;
   let abilityService: CaslAbilityService;
+  let pessoaService: PessoaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UsersService,
+        PessoaService,
         CaslAbilityService,
         {
           provide: PrismaService,
@@ -22,115 +28,44 @@ describe('UsersService', () => {
             create: jest.fn(),
           },
         },
+        {
+          provide: EstadoCivilService,
+          useValue: {},
+        },
+        {
+          provide: EscolaridadeService,
+          useValue: {},
+        },
+        {
+          provide: SituacaoReligiosaService,
+          useValue: {},
+        },
+        {
+          provide: TipoCarismaPrimitivoService,
+          useValue: {},
+        },
+        {
+          provide: TipoCarismaVinculadoService,
+          useValue: {},
+        },
+        {
+          provide: TipoCarismaServicoService,
+          useValue: {},
+        },
       ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
+    pessoaService = module.get<PessoaService>(PessoaService);
     prismaService = module.get<PrismaService>(PrismaService);
-    abilityService = await module.resolve<CaslAbilityService>(CaslAbilityService);
+    abilityService =
+      await module.resolve<CaslAbilityService>(CaslAbilityService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
     expect(prismaService).toBeDefined();
     expect(abilityService).toBeDefined();
+    expect(pessoaService).toBeDefined();
   });
-
-  describe('UsersService', () => {
-    let service: UsersService;
-    let prismaService: any;
-    let abilityService: any;
-
-    beforeEach(async () => {
-      prismaService = {
-        user: {
-          create: jest.fn(),
-          findMany: jest.fn(),
-          findUnique: jest.fn(),
-          update: jest.fn(),
-          delete: jest.fn(),
-        },
-      };
-      abilityService = {
-        ability: {
-          can: jest.fn(),
-        },
-      };
-      service = new UsersService(prismaService, abilityService);
-    });
-
-    describe('create', () => {
-      it('should hash password and create user with default role', async () => {
-        const dto = { username: 'test', password: 'pass123' };
-        prismaService.user.create.mockResolvedValue({ id: '1', ...dto, role: ROLE_ENUM.NAO_IDENTIFICADO });
-        const result = await service.create(dto as any);
-        expect(bcrypt.hash).toBeDefined();
-        expect(prismaService.user.create).toHaveBeenCalledWith({
-          data: expect.objectContaining({
-            username: 'test',
-            role: ROLE_ENUM.NAO_IDENTIFICADO,
-          }),
-        });
-        expect(result.role).toBe(ROLE_ENUM.NAO_IDENTIFICADO);
-      });
-    });
-
-    describe('findAll', () => {
-      it('should return users if ability allows', async () => {
-        abilityService.ability.can.mockReturnValue(true);
-        prismaService.user.findMany.mockResolvedValue([{ id: '1' }]);
-        const result = await service.findAll();
-        expect(prismaService.user.findMany).toHaveBeenCalled();
-        expect(result).toEqual([{ id: '1' }]);
-      });
-
-      it('should throw ForbiddenException if ability denies', () => {
-        abilityService.ability.can.mockReturnValue(false);
-        expect(() => service.findAll()).toThrow(ForbiddenException);
-      });
-    });
-
-    describe('findOne', () => {
-      it('should return user by id', async () => {
-        prismaService.user.findUnique.mockResolvedValue({ id: '1' });
-        const result = await service.findOne('1');
-        expect(prismaService.user.findUnique).toHaveBeenCalledWith({ where: { id: '1' } });
-        expect(result).toEqual({ id: '1' });
-      });
-    });
-
-    describe('update', () => {
-      it('should hash password if provided and update user', async () => {
-        const dto = { password: 'newpass', username: 'updated' };
-        prismaService.user.update.mockResolvedValue({ id: '1', ...dto });
-        const result = await service.update('1', { ...dto } as any);
-        expect(prismaService.user.update).toHaveBeenCalledWith({
-          where: { id: '1' },
-          data: expect.objectContaining({ username: 'updated' }),
-        });
-        expect(result.id).toBe('1');
-      });
-
-      it('should update user without hashing if password not provided', async () => {
-        const dto = { username: 'updated' };
-        prismaService.user.update.mockResolvedValue({ id: '1', ...dto });
-        const result = await service.update('1', { ...dto } as any);
-        expect(prismaService.user.update).toHaveBeenCalledWith({
-          where: { id: '1' },
-          data: expect.objectContaining({ username: 'updated' }),
-        });
-        expect(result.id).toBe('1');
-      });
-    });
-
-    describe('remove', () => {
-      it('should delete user by id', async () => {
-        prismaService.user.delete.mockResolvedValue({ id: '1' });
-        const result = await service.remove('1');
-        expect(prismaService.user.delete).toHaveBeenCalledWith({ where: { id: '1' } });
-        expect(result).toEqual({ id: '1' });
-      });
-    });
-  });
-  
 });

--- a/test/users/user.e2e-spec.ts
+++ b/test/users/user.e2e-spec.ts
@@ -8,6 +8,7 @@ describe('UserController (e2e)', () => {
   let app: INestApplication;
   const email = faker.internet.email();
   const name = faker.person.fullName();
+  const cpf = '07244455569';
   const password = faker.internet.password();
   const whatsapp = '16999999999';
 
@@ -44,6 +45,7 @@ describe('UserController (e2e)', () => {
   it('/users (POST) - Deve criar um usuário com sucesso', async () => {
     const response = await request(app.getHttpServer()).post('/users').send({
       email,
+      cpf,
       password,
       name,
       whatsapp,
@@ -57,6 +59,7 @@ describe('UserController (e2e)', () => {
       data: {
         email,
         name,
+        cpf,
         role: ROLE_ENUM.NAO_IDENTIFICADO,
         whatsapp,
         verifiedWhatsapp: false,
@@ -76,6 +79,7 @@ describe('UserController (e2e)', () => {
   it('/users (POST) - Não deve permitir e-mail duplicado', async () => {
     const response = await request(app.getHttpServer()).post('/users').send({
       email,
+      cpf: '07211133215',
       password: 'admin',
       name,
       whatsapp,
@@ -84,6 +88,21 @@ describe('UserController (e2e)', () => {
     expect(response.status).toBe(400);
     expect(response.body.message).toContain(
       `O campo 'email' já existe cadastrado. Não permitimos duplicidade.`,
+    );
+  });
+
+  it('/users (POST) - Não deve permitir CPF duplicado', async () => {
+    const response = await request(app.getHttpServer()).post('/users').send({
+      email,
+      cpf,
+      password: 'admin',
+      name,
+      whatsapp,
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body.message).toContain(
+      `Já tem um usuario com esse CPF ${cpf}`,
     );
   });
 


### PR DESCRIPTION
```markdown
## Resumo por Sourcery

Integrar o tratamento de CPF na criação de usuários, aplicar permissões de criação em Diocese e Paróquia, refinar métodos de filtragem de permissões e atualizar o esquema do banco de dados de acordo.

Novas Funcionalidades:
- Adicionar suporte a CPF no registro de usuários com validação de formato, verificação de unicidade e link opcional para um registro de Pessoa existente
- Adicionar verificações de autorização para proteger operações de criação em DioceseService e ParoquiaService

Melhorias:
- Refinar a filtragem de permissões em DioceseService renomeando o método para asPermissionsRead
- Refatorar PessoaService para expor findOneByCpf e tornar analisarCPF público para reuso

Estrutura:
- Adicionar migração de banco de dados para estender a tabela de usuário com as colunas cpf e pessoaId e restrição de chave estrangeira
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate CPF handling into user creation, enforce creation permissions on Diocese and Paroquia, refine permission filtering methods, and update the database schema accordingly

New Features:
- Add CPF support to user registration with format validation, uniqueness check, and optional link to existing Pessoa record
- Add authorization checks to protect creation operations in DioceseService and ParoquiaService

Enhancements:
- Refine permission filtering in DioceseService by renaming method to asPermissionsRead
- Refactor PessoaService to expose findOneByCpf and make analisarCPF public for reuse

Build:
- Add database migration to extend user table with cpf and pessoaId columns and foreign key constraint

</details>